### PR TITLE
Add the rest of the attachment fields to Attachment struct

### DIFF
--- a/src/attachment.rs
+++ b/src/attachment.rs
@@ -19,6 +19,26 @@ pub struct Attachment {
     /// Fields are defined as an array, and hashes contained within it will be
     /// displayed in a table inside the message attachment.
     pub fields: Option<Vec<Field>>,
+    /// Optional text that appears above the attachment block
+    pub author_name: Option<SlackText>,
+    /// Optional link to the author
+    pub author_link: Option<SlackText>,
+    /// Optional icon for the author
+    pub author_icon: Option<SlackText>,
+    /// Optional larger, bolder text above the main body
+    pub title: Option<SlackText>,
+    /// Optional URL to link to from the title
+    pub title_link: Option<SlackText>,
+    /// Optional URL to an image that will be displayed in the body
+    pub image_url: Option<SlackText>,
+    /// Optional URL to an image that will be displayed as a thumbnail to the
+    /// right of the body
+    pub thumb_url: Option<SlackText>,
+    /// Optional text that will appear at the bottom of the attachment
+    pub footer: Option<SlackText>,
+    /// Optional URL to an image that will be displayed at the bottom of the
+    /// attachment
+    pub footer_icon: Option<SlackText>,
 }
 
 /// Attachment template to simplify constructing attachments
@@ -39,6 +59,26 @@ pub enum AttachmentTemplate<'a> {
         /// Fields are defined as an array, and hashes contained within it will
         /// be displayed in a table inside the message attachment.
         fields: Option<Vec<Field>>,
+        /// Optional text that appears above the attachment block
+        author_name: Option<&'a str>,
+        /// Optional link to the author
+        author_link: Option<&'a str>,
+        /// Optional icon for the author
+        author_icon: Option<&'a str>,
+        /// Optional larger, bolder text above the main body
+        title: Option<&'a str>,
+        /// Optional URL to link to from the title
+        title_link: Option<&'a str>,
+        /// Optional URL to an image that will be displayed in the body
+        image_url: Option<&'a str>,
+        /// Optional URL to an image that will be displayed as a thumbnail to the
+        /// right of the body
+        thumb_url: Option<&'a str>,
+        /// Optional text that will appear at the bottom of the attachment
+        footer: Option<&'a str>,
+        /// Optional URL to an image that will be displayed at the bottom of the
+        /// attachment
+        footer_icon: Option<&'a str>,
     },
     /// Provide only text and color for attachment
     /// other values will be defaulted
@@ -54,7 +94,11 @@ impl Attachment {
     /// Construct new attachment based on template provided
     pub fn new(t: AttachmentTemplate) -> SlackResult<Attachment> {
         match t {
-            AttachmentTemplate::Complete { fallback, text, pretext, color, fields } => {
+            AttachmentTemplate::Complete {
+                fallback, text, pretext, color, fields, author_name,
+                author_link, author_icon, title, title_link, image_url,
+                thumb_url, footer, footer_icon
+            } => {
                 let c = try!(HexColorT::new(color));
                 Ok(Attachment {
                     fallback: SlackText::new(fallback),
@@ -62,6 +106,15 @@ impl Attachment {
                     pretext: opt_str_to_slacktext(&pretext),
                     color: c,
                     fields: fields,
+                    author_name: opt_str_to_slacktext(&author_name),
+                    author_link: opt_str_to_slacktext(&author_link),
+                    author_icon: opt_str_to_slacktext(&author_icon),
+                    title: opt_str_to_slacktext(&title),
+                    title_link: opt_str_to_slacktext(&title_link),
+                    image_url: opt_str_to_slacktext(&image_url),
+                    thumb_url: opt_str_to_slacktext(&thumb_url),
+                    footer: opt_str_to_slacktext(&footer),
+                    footer_icon: opt_str_to_slacktext(&footer_icon),
                 })
             }
             AttachmentTemplate::Text { text, color } => {
@@ -72,6 +125,15 @@ impl Attachment {
                     pretext: None,
                     color: c,
                     fields: None,
+                    author_name: None,
+                    author_link: None,
+                    author_icon: None,
+                    title: None,
+                    title_link: None,
+                    image_url: None,
+                    thumb_url: None,
+                    footer: None,
+                    footer_icon: None,
                 })
             }
         }

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -174,8 +174,16 @@ mod test {
                          pretext: None,
                          color: "#6800e8",
                          fields: Some(vec![Field::new("title", "value", None)]),
-                     })
-                         .unwrap()];
+                         author_name: Some("Author"),
+                         author_link: Some("https://author.com"),
+                         author_icon: Some("https://author.com/icon"),
+                         title: Some("Title"),
+                         title_link: Some("https://title.com"),
+                         image_url: Some("https://title.com/image"),
+                         thumb_url: Some("https://title.com/thumb"),
+                         footer: Some("Footer"),
+                         footer_icon: Some("https://footer.com/icon"),
+                     }).unwrap()];
 
         let p = Payload::new(PayloadTemplate::Complete {
             text: Some("test message"),
@@ -188,7 +196,7 @@ mod test {
             link_names: Some(false),
         });
 
-        assert_eq!(json::encode(&p).unwrap().to_owned(), r##"{"text":"test message","channel":"#abc","username":"Bot","icon_url":null,"icon_emoji":":chart_with_upwards_trend:","attachments":[{"fallback":"fallback &lt;&amp;&gt;","text":"text &lt;&amp;&gt;","pretext":null,"color":"#6800e8","fields":[{"title":"title","value":"value","short":null}]}],"unfurl_links":0,"link_names":0}"##.to_owned())
+        assert_eq!(json::encode(&p).unwrap().to_owned(), r##"{"text":"test message","channel":"#abc","username":"Bot","icon_url":null,"icon_emoji":":chart_with_upwards_trend:","attachments":[{"fallback":"fallback &lt;&amp;&gt;","text":"text &lt;&amp;&gt;","pretext":null,"color":"#6800e8","fields":[{"title":"title","value":"value","short":null}],"author_name":"Author","author_link":"https://author.com","author_icon":"https://author.com/icon","title":"Title","title_link":"https://title.com","image_url":"https://title.com/image","thumb_url":"https://title.com/thumb","footer":"Footer","footer_icon":"https://footer.com/icon"}],"unfurl_links":0,"link_names":0}"##.to_owned())
     }
 
     #[test]


### PR DESCRIPTION
Support the rest of the attachment fields detailed here: https://api.slack.com/docs/message-attachments#attachment_structure