### PR TITLE
Major refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,11 +29,12 @@ FEATURES
  fixed.
  - `Payload`
   - Added `unfurl_media` option
-- Three character hex color codes, e.g. `#000`, are now supported.
-- Add support for sending links and text into slack, see:
-[Text with Links](README.md#text-with-links).
-- Optional fields no longer are sent in the serialized json message to slack.
-- Add `parse` option to `Payload`.
+ - Three character hex color codes, e.g. `#000`, are now supported.
+ - Add support for sending links and text into slack, see:
+ [Text with Links](README.md#text-with-links).
+ - Optional fields no longer are sent in the serialized json message to slack.
+ - Add `parse` option to `Payload`.
+ - New `Attachment` fields have been added.
 
 OTHER
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,10 @@ FEATURES
  fixed.
  - `Payload`
   - Added `unfurl_media` option
+- Three character hex color codes, e.g. `#000`, are now supported.
 
 OTHER
+
  - `TryFrom` and `TryInto` traits have been added temporarily to this crate until they are
  formalized in rust proper. See https://github.com/rust-lang/rust/issues/33417 for details.
  - `HexColorT` trait removed. Conversions are used instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ FEATURES
 - Add support for sending links and text into slack, see:
 [Text with Links](README.md#text-with-links).
 - Optional fields no longer are sent in the serialized json message to slack.
+- Add `parse` option to `Payload`.
 
 OTHER
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 DEPRECATIONS/BREAKING CHANGES:
 
+ - `Payload`
+  - `PayloadTemplate` is removed.
+  - `unfurl_links` is now bool. No integer transformation is required by the slack API anymore.
+ - `Attachment`
+  - `AttachmentTemplate` is removed.
+  - `color` is now optional.
  - `SlackError` is now `Error` and `SlackResult` is now `Result`. In addition, `ErrorKind` has been
  removed. All `Error` variants have also been renamed, removing the superfluous `Err` prefix:
   - `ErrSlackResp` -> `Slack`
@@ -10,3 +16,20 @@ DEPRECATIONS/BREAKING CHANGES:
   - `ErrHexColor` -> `HexColor`
   - `ErrEncoder` -> `Encoder`
   - `ErrCurl` -> `Curl`
+ - `SlackLink`, `SlackText`
+  - The `Display` trait is now used to format strings for sending to slack rather than `Debug`.
+  The `Debug` impl is derived now.
+
+FEATURES
+
+ - `PayloadBuilder` and `AttachmentBuilder` should be used for building a `Payload` or `Attachment`
+ respectively. Errors won't be returned until the final `build` function is called. At this point,
+ only the first error is displayed. Subsequent errors will only appear once the first error is
+ fixed.
+ - `Payload`
+  - Added `unfurl_media` option
+
+OTHER
+ - `TryFrom` and `TryInto` traits have been added temporarily to this crate until they are
+ formalized in rust proper. See https://github.com/rust-lang/rust/issues/33417 for details.
+ - `HexColorT` trait removed. Conversions are used instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ FEATURES
  - `Payload`
   - Added `unfurl_media` option
 - Three character hex color codes, e.g. `#000`, are now supported.
+- Add support for sending links and text into slack, see:
+[Text with Links](README.md#text-with-links).
 
 OTHER
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ FEATURES
 - Three character hex color codes, e.g. `#000`, are now supported.
 - Add support for sending links and text into slack, see:
 [Text with Links](README.md#text-with-links).
+- Optional fields no longer are sent in the serialized json message to slack.
 
 OTHER
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ DEPRECATIONS/BREAKING CHANGES:
  - `SlackLink`, `SlackText`
   - The `Display` trait is now used to format strings for sending to slack rather than `Debug`.
   The `Debug` impl is derived now.
+ - `Slack::new` now returns a `Result<Slack>` as it does `Url` parsing.
 
 FEATURES
 

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,4 +1,4 @@
 This project is dual-licensed under the terms of the MIT and Apache (version 2.0) licenses.
 
-Copyright (c) 2014 Christopher Brickley and the rust-slack project developers
+Copyright (c) 2016 Christopher Brickley and the rust-slack project developers
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ log = "0.3.6"
 quick-error = "1.1.0"
 serde = "0.8.8"
 serde_json = "0.8.1"
+url = { version = "1.2.0", features = ["serde"] }
 
 [dependencies.clippy]
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,19 +13,24 @@ version = "0.1.3"
 [build-dependencies]
 serde = "0.8.8"
 serde_codegen = "0.8.8"
+chrono = "0.2.25"
 
 [dependencies]
+chrono = "0.2.25"
 curl = "0.3.0"
 hex = "0.2.0"
 log = "0.3.6"
 quick-error = "1.1.0"
 serde = "0.8.8"
 serde_json = "0.8.1"
-url = { version = "1.2.0", features = ["serde"] }
 
 [dependencies.clippy]
 optional = true
 version = "^0.0"
+
+[dependencies.url]
+features = ["serde"]
+version = "1.2.0"
 
 [features]
 unstable = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 authors = ["Christopher Brickley <brickley@gmail.com>"]
+build = "build.rs"
 description = "A rust crate for sending messages to Slack via webhooks."
 homepage = "https://github.com/frostly/rust-slack"
 keywords = ["slack", "webhook", "hook", "messaging"]
@@ -9,11 +10,16 @@ readme = "README.md"
 repository = "https://github.com/frostly/rust-slack"
 version = "0.1.3"
 
+[build-dependencies]
+serde_codegen = "0.8.8"
+
 [dependencies]
 curl = "0.3.0"
+hex = "0.2.0"
 log = "0.3.6"
 quick-error = "1.1.0"
-rustc-serialize = "0.3.19"
+serde = "0.8.8"
+serde_json = "0.8.1"
 
 [dependencies.clippy]
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/frostly/rust-slack"
 version = "0.1.3"
 
 [build-dependencies]
+serde = "0.8.8"
 serde_codegen = "0.8.8"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,3 @@ version = "^0.0"
 [dependencies.url]
 features = ["serde"]
 version = "1.2.0"
-
-[features]
-unstable = []

--- a/README.md
+++ b/README.md
@@ -59,6 +59,35 @@ fn main() {
 }
 ```
 
+## Text with Links
+
+Slack messaging API permits you to send links within text. However, given the different formatting
+rules, these text fragments need to be specified as follows:
+
+```rust
+extern crate slack_hook;
+use slack_hook::{PayloadBuilder, SlackTextContent, SlackLink};
+use slack_hook::SlackTextContent::{Text, Link};
+
+fn main() {
+  let p = PayloadBuilder::new()
+    .text(vec![
+      Text("Hello".into()),
+      Link(SlackLink::new("https://google.com", "Google")),
+      Text(", nice to know you.".into())
+    ].as_slice())
+    .build()
+    .unwrap();
+}
+```
+
+Sending this payload will print the following in slack (note: each element of the `Vec` has been
+space-separated):
+
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Hello [Google](https://google.com), nice to know you.
+
+This technique can be used for any function that has the `Into<SlackText>` trait bound.
+
 # License
 
 This library is distributed under similar terms to Rust: dual licensed under the MIT license and the Apache license (version 2.0).

--- a/README.md
+++ b/README.md
@@ -23,20 +23,17 @@ Add the crate to your existing project:
 
 ```rust,no_run
 extern crate slack_hook;
-use slack_hook::{Slack, Payload, PayloadTemplate};
+use slack_hook::{Slack, PayloadBuilder};
 
 fn main() {
     let slack = Slack::new("https://hooks.slack.com/services/abc/123/45z");
-    let p = Payload::new(PayloadTemplate::Complete {
-      text: Some("test message"),
-      channel: Some("#testing"),
-      username: Some("My Bot"),
-      icon_url: None,
-      icon_emoji: Some(":chart_with_upwards_trend:"),
-      attachments: None,
-      unfurl_links: Some(true),
-      link_names: Some(false)
-    });
+    let p = PayloadBuilder::new()
+      .text("test message")
+      .channel("#testing")
+      .username("My Bot")
+      .icon_emoji(":chart_with_upwards_trend:")
+      .build()
+      .unwrap();
 
     let res = slack.send(&p);
     match res {
@@ -52,15 +49,13 @@ To create a payload with just an attachment:
 
 ```rust
 extern crate slack_hook;
-use slack_hook::{Payload, PayloadTemplate, Attachment, AttachmentTemplate};
+use slack_hook::{PayloadBuilder, AttachmentBuilder};
 
 fn main() {
-  let p = Payload::new(PayloadTemplate::Attachment {
-    attachment: Attachment::new(AttachmentTemplate::Text {
-      text: "my text",
-      color: "#b13d41",
-    }).unwrap(),
-  });
+  let p = PayloadBuilder::new()
+    .attachments(vec![AttachmentBuilder::new("my text").color("#b13d41").build().unwrap()])
+    .build()
+    .unwrap();
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,13 +10,15 @@ A rust crate for sending messages to Slack via webhooks.
 
 [Slack](https://slack.com/) is a messaging platform for team collaboration.
 
+Upgrading from `0.1`? See the [CHANGELOG](./CHANGELOG.md).
+
 # Usage
 
 Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-slack-hook = "0.1"
+slack-hook = "0.2"
 ```
 
 Add the crate to your existing project:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ extern crate slack_hook;
 use slack_hook::{Slack, PayloadBuilder};
 
 fn main() {
-    let slack = Slack::new("https://hooks.slack.com/services/abc/123/45z");
+    let slack = Slack::new("https://hooks.slack.com/services/abc/123/45z").unwrap();
     let p = PayloadBuilder::new()
       .text("test message")
       .channel("#testing")

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,13 @@
+extern crate serde_codegen;
+
+use std::env;
+use std::path::Path;
+
+fn main() {
+    let out_dir = env::var_os("OUT_DIR").unwrap();
+
+    let src = Path::new("src/serde_types.in.rs");
+    let dst = Path::new(&out_dir).join("serde_types.rs");
+
+    serde_codegen::expand(&src, &dst).unwrap();
+}

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,6 @@
 extern crate serde_codegen;
 extern crate serde;
+extern crate chrono;
 
 use std::env;
 use std::path::Path;

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,5 @@
 extern crate serde_codegen;
+extern crate serde;
 
 use std::env;
 use std::path::Path;

--- a/src/attachment.rs
+++ b/src/attachment.rs
@@ -1,40 +1,5 @@
-use slack::SlackText;
 use error::{Error, Result};
-use hex::HexColor;
-use TryInto;
-
-/// Slack allows for attachments to be added to messages. See
-/// https://api.slack.com/docs/attachments for more information.
-#[derive(RustcEncodable, Debug, Default)]
-pub struct Attachment {
-    /// Required text for attachment.
-    /// Slack will use this text to display on devices that don't support markup.
-    pub fallback: SlackText,
-    /// Optional text for other devices, markup supported
-    pub text: Option<SlackText>,
-    /// Optional text that appears above attachment
-    pub pretext: Option<SlackText>,
-    /// Optional color of attachment
-    pub color: Option<HexColor>,
-    /// Fields are defined as an array, and hashes contained within it will be
-    /// displayed in a table inside the message attachment.
-    pub fields: Option<Vec<Field>>,
-}
-
-/// Fields are defined as an array, and hashes contained within it will
-/// be displayed in a table inside the message attachment.
-#[derive(RustcEncodable, Debug)]
-pub struct Field {
-    /// Shown as a bold heading above the value text.
-    /// It cannot contain markup and will be escaped for you.
-    pub title: String,
-    /// The text value of the field. It may contain standard message markup
-    /// and must be escaped as normal. May be multi-line.
-    pub value: SlackText,
-    /// An optional flag indicating whether the value is short enough to be
-    /// displayed side-by-side with other values.
-    pub short: Option<bool>,
-}
+use {Attachment, Field, HexColor, SlackText, TryInto};
 
 impl Field {
     /// Construct a new field

--- a/src/attachment.rs
+++ b/src/attachment.rs
@@ -1,5 +1,7 @@
 use error::{Error, Result};
-use {Attachment, Field, HexColor, SlackText, TryInto};
+use {Attachment, Field, HexColor, SlackText, TryInto, SlackTime};
+use chrono::NaiveDateTime;
+use url::Url;
 
 impl Field {
     /// Construct a new field
@@ -83,6 +85,79 @@ impl AttachmentBuilder {
         match self.inner {
             Ok(mut inner) => {
                 inner.fields = Some(fields);
+                AttachmentBuilder { inner: Ok(inner) }
+            }
+            _ => self,
+        }
+    }
+    /// Optional small text used to display the author's name.
+    pub fn author_name<S: Into<SlackText>>(self, author_name: S) -> AttachmentBuilder {
+        match self.inner {
+            Ok(mut inner) => {
+                inner.author_name = Some(author_name.into());
+                AttachmentBuilder { inner: Ok(inner) }
+            }
+            _ => self,
+        }
+    }
+
+    url_builder_fn! {
+        /// Optional URL that will hyperlink the `author_name`.
+        author_link, AttachmentBuilder
+    }
+
+    url_builder_fn! {
+        /// Optional URL that displays a small 16x16px image to the left of the `author_name` text.
+        author_icon, AttachmentBuilder
+    }
+
+    /// Optional larger, bolder text above the main body
+    pub fn title<S: Into<SlackText>>(self, title: S) -> AttachmentBuilder {
+        match self.inner {
+            Ok(mut inner) => {
+                inner.title = Some(title.into());
+                AttachmentBuilder { inner: Ok(inner) }
+            }
+            _ => self,
+        }
+    }
+
+    url_builder_fn! {
+        /// Optional URL to link to from the title
+        title_link, AttachmentBuilder
+    }
+
+    url_builder_fn! {
+        /// Optional URL to an image that will be displayed in the body
+        image_url, AttachmentBuilder
+    }
+
+    url_builder_fn! {
+        /// Optional URL to an image that will be displayed as a thumbnail to the right of the body
+        thumb_url, AttachmentBuilder
+    }
+
+    /// Optional text that will appear at the bottom of the attachment
+    pub fn footer<S: Into<SlackText>>(self, footer: S) -> AttachmentBuilder {
+        match self.inner {
+            Ok(mut inner) => {
+                inner.footer = Some(footer.into());
+                AttachmentBuilder { inner: Ok(inner) }
+            }
+            _ => self,
+        }
+    }
+
+    url_builder_fn! {
+        /// Optional URL to an image that will be displayed at the bottom of the attachment
+        footer_icon, AttachmentBuilder
+    }
+
+    /// Optional timestamp to be displayed with the attachment
+    pub fn ts(self, time: &NaiveDateTime) -> AttachmentBuilder {
+        match self.inner {
+            Ok(mut inner) => {
+                inner.ts = Some(SlackTime::new(time));
                 AttachmentBuilder { inner: Ok(inner) }
             }
             _ => self,

--- a/src/attachment.rs
+++ b/src/attachment.rs
@@ -81,9 +81,9 @@ impl AttachmentBuilder {
     ///
     /// The color can be one of:
     ///
-    /// 1. The built-in `SlackColor` variants: `SlackColor::Good`, etc.
-    /// 1. Any valid color `String`: good`, `warning`, `danger`
-    /// 3. Any valid hex color code: `#b13d41`
+    /// 1. `String`s: `good`, `warning`, `danger`
+    /// 2. The built-in enums: `SlackColor::Good`, etc.
+    /// 3. Any valid hex color code: e.g. `#b13d41` or `#000`.
     ///
     /// hex color codes will be checked to ensure a valid hex number is provided
     pub fn color<C: TryInto<HexColor, Err = Error>>(self, color: C) -> AttachmentBuilder {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 use hexx;
 use curl;
 use serde_json;
+use url;
 
 /// `Result` type-alias
 pub type Result<T> = ::std::result::Result<T, Error>;
@@ -46,6 +47,14 @@ quick_error! {
             description("curl error")
             display("curl error: {}", err)
             cause(err)
+        }
+        /// `Url` parsing error
+        Url(err: url::ParseError) {
+            from()
+            description("url parse error")
+            display("url parse error: {}", err)
+            cause(err)
+
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
-use rustc_serialize;
+use hexx;
 use curl;
+use serde_json;
 
 /// `Result` type-alias
 pub type Result<T> = ::std::result::Result<T, Error>;
@@ -20,18 +21,18 @@ quick_error! {
             display("utf8 error: {}", err)
             cause(err)
         }
-        /// `rustc_serialize::json::EncoderError`
-        Encoder(err: rustc_serialize::json::EncoderError) {
+        /// `serde_json::error::Error`
+        Serialize(err: serde_json::error::Error) {
             from()
-            description("rustc_serialize::json::EncoderError")
-            display("rustc_serialize::json::EncoderError: {}", err)
+            description("serde_json::error::Error")
+            display("serde_json::error::Error: {}", err)
             cause(err)
         }
         /// `rustc_serialize::hex::FromHexError`
-        FromHex(err: rustc_serialize::hex::FromHexError) {
+        FromHex(err: hexx::FromHexError) {
             from()
-            description("rustcrustc_serialize::hex::FromHexError")
-            display("rustc_serialize::hex::FromHexError: {}", err)
+            description("hexx::FromHexError")
+            display("hexx::FromHexError: {}", err)
             cause(err)
         }
         /// `HexColor` parsing error

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -1,26 +1,6 @@
-use slack::SlackText;
-
-/// Convert an `Option<bool>` to `Option<0/1>`
-pub fn opt_bool_to_u8(opt: &Option<bool>) -> Option<u8> {
-    match *opt {
-        Some(true) => Some(1u8),
-        Some(false) => Some(0u8),
-        _ => None,
-    }
-}
-
-/// Convert a `Option<&str>` to an `Option<String>`
-pub fn opt_str_to_string(opt: &Option<&str>) -> Option<String> {
-    match *opt {
-        Some(x) => Some(x.to_owned()),
-        _ => None,
-    }
-}
-
-/// Convert an `Option<&str>` to a `Option<SlackText>`
-pub fn opt_str_to_slacktext(opt: &Option<&str>) -> Option<SlackText> {
-    match *opt {
-        Some(x) => Some(x.into()),
-        _ => None,
+pub fn bool_to_u8(b: bool) -> u8 {
+    match b {
+        true => 1u8,
+        false => 0u8,
     }
 }

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -1,6 +1,3 @@
 pub fn bool_to_u8(b: bool) -> u8 {
-    match b {
-        true => 1u8,
-        false => 0u8,
-    }
+    if b { 1u8 } else { 0u8 }
 }

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -1,16 +1,36 @@
-use std::fmt;
-use error::{Result, Error};
+use error::Error;
 use rustc_serialize::hex::FromHex;
 use rustc_serialize::json::{ToJson, Json};
 use rustc_serialize::{Encodable, Encoder};
+use TryFrom;
 
 /// The `HexColor` string can be one of:
 ///
 /// 1. `good`, `warning`, `danger`
 /// 2. The built-in enums: `SlackColor::Good`, etc.
 /// 3. Any valid hex color code: `#b13d41`
+///
 /// hex color codes will be checked to ensure a valid hex number is provided
+#[derive(Debug)]
 pub struct HexColor(String);
+
+impl HexColor {
+    fn new<S: Into<String>>(s: S) -> HexColor {
+        HexColor(s.into())
+    }
+}
+
+impl Default for HexColor {
+    fn default() -> HexColor {
+        HexColor::new("#000000")
+    }
+}
+
+impl ::std::fmt::Display for HexColor {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 /// Default slack colors built-in to the API
 /// See: https://api.slack.com/docs/attachments
@@ -31,10 +51,9 @@ const SLACK_COLORS: [&'static str; 3] = [// SlackColor::Good.as_slice(),
                                          "warning",
                                          "danger"];
 
-
-impl ToString for SlackColor {
-    fn to_string(&self) -> String {
-        String::from(self.as_ref())
+impl ::std::fmt::Display for SlackColor {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{}", self.as_ref())
     }
 }
 
@@ -48,97 +67,77 @@ impl AsRef<str> for SlackColor {
     }
 }
 
-impl fmt::Debug for HexColor {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let HexColor(ref text) = *self;
-        write!(f, "{}", text)
+impl From<SlackColor> for HexColor {
+    fn from(color: SlackColor) -> HexColor {
+        HexColor::new(color.to_string())
     }
 }
 
-/// Trait to support constructing `HexColors` via different types
-pub trait HexColorT {
-    /// &T is input type for constructor
-    type T: ?Sized;
-    /// construct new instance of `Self` for `T`
-    fn new(t: &Self::T) -> Self;
-}
-
-impl HexColorT for Result<HexColor> {
-    type T = str;
-    fn new(s: &str) -> Result<HexColor> {
-        Ok(try!(s.into_hex_color()))
+impl<S> TryFrom<S> for HexColor
+    where S: Into<String>
+{
+    type Err = Error;
+    fn try_from(s: S) -> ::std::result::Result<Self, Self::Err> {
+        let s: String = s.into();
+        if SLACK_COLORS.contains(&&s[..]) {
+            return Ok(HexColor(s));
+        }
+        if s.chars().count() != 7 {
+            return Err(Error::HexColor("Must be 7 characters long (including #)".to_string()));
+        }
+        if s.chars().next().unwrap() != '#' {
+            return Err(Error::HexColor("No leading #".to_string()));
+        }
+        // see if the remaining part of the string is actually hex
+        match s[1..].from_hex() {
+            Ok(_) => Ok(HexColor(s)),
+            Err(e) => Err(e.into()),
+        }
     }
 }
 
-impl HexColorT for HexColor {
-    type T = SlackColor;
-
-    fn new(color: &SlackColor) -> HexColor {
-        HexColor(color.to_string())
+// even though this will always succeed, it simplifies the trait bound in the builder
+impl TryFrom<SlackColor> for HexColor {
+    type Err = Error;
+    fn try_from(color: SlackColor) -> ::std::result::Result<Self, Self::Err> {
+        Ok(color.into())
     }
 }
 
 impl ToJson for HexColor {
     fn to_json(&self) -> Json {
-        Json::String(format!("{:?}", &self))
+        Json::String(format!("{}", &self))
     }
 }
 
 impl Encodable for HexColor {
     fn encode<S: Encoder>(&self, encoder: &mut S) -> ::std::result::Result<(), S::Error> {
-        encoder.emit_str(format!("{:?}", &self).as_ref())
-    }
-}
-
-
-/// A trait for turning self into a `HexColor`
-trait IntoHexColor {
-    /// function to attempt to make a `HexColor` from `self`
-    fn into_hex_color(self) -> Result<HexColor>;
-}
-
-impl<'a> IntoHexColor for &'a str {
-    /// Attempt to convert a &str into a `HexColor`
-    fn into_hex_color(self) -> Result<HexColor> {
-        if SLACK_COLORS.contains(&self) {
-            return Ok(HexColor(self.to_owned()));
-        }
-        if self.chars().count() != 7 {
-            return Err(Error::HexColor("Must be 7 characters long (including #)".to_string()));
-        }
-        if self.chars().next().unwrap() != '#' {
-            return Err(Error::HexColor("No leading #".to_string()));
-        }
-        // see if the remaining part of the string is actually hex
-        match self[1..].from_hex() {
-            Ok(_) => Ok(HexColor(self.to_owned())),
-            Err(e) => Err(e.into()),
-        }
+        encoder.emit_str(format!("{}", &self).as_ref())
     }
 }
 
 #[cfg(test)]
 mod test {
     use hex::*;
-    use error::Result;
+    use TryFrom;
 
     #[test]
     fn test_hex_color_too_short() {
-        let err = <Result<HexColor> as HexColorT>::new("abc").unwrap_err();
+        let err = HexColor::try_from("abc").unwrap_err();
         assert_eq!(format!("{}", err),
                    "hex color parsing error: Must be 7 characters long (including #)".to_owned());
     }
 
     #[test]
     fn test_hex_color_missing_hash() {
-        let err = <Result<HexColor> as HexColorT>::new("1234567").unwrap_err();
+        let err = HexColor::try_from("1234567").unwrap_err();
         assert_eq!(format!("{}", err),
                    "hex color parsing error: No leading #".to_owned());
     }
 
     #[test]
     fn test_hex_color_invalid_hex_fmt() {
-        let err = <Result<HexColor> as HexColorT>::new("#abc12z").unwrap_err();
+        let err = HexColor::try_from("#abc12z").unwrap_err();
         assert_eq!(format!("{}", err),
                    "rustc_serialize::hex::FromHexError: Invalid character 'z' at position 5"
                        .to_owned());
@@ -146,25 +145,25 @@ mod test {
 
     #[test]
     fn test_hex_color_good() {
-        let h: HexColor = HexColorT::new(&SlackColor::Good);
-        assert_eq!(format!("{:?}", h), "good".to_owned());
+        let h: HexColor = HexColor::try_from(SlackColor::Good).unwrap();
+        assert_eq!(format!("{}", h), "good".to_owned());
     }
 
     #[test]
     fn test_hex_color_danger_str() {
-        let ok = <Result<HexColor> as HexColorT>::new("danger").unwrap();
-        assert_eq!(format!("{:?}", ok), "danger".to_owned());
+        let ok = HexColor::try_from("danger").unwrap();
+        assert_eq!(format!("{}", ok), "danger".to_owned());
     }
 
     #[test]
     fn test_hex_color_valid_upper_hex() {
-        let ok = <Result<HexColor> as HexColorT>::new("#103D18").unwrap();
-        assert_eq!(format!("{:?}", ok), "#103D18".to_owned());
+        let ok = HexColor::try_from("#103D18").unwrap();
+        assert_eq!(format!("{}", ok), "#103D18".to_owned());
     }
 
     #[test]
     fn test_hex_color_valid_lower_hex() {
-        let ok = <Result<HexColor> as HexColorT>::new("#103d18").unwrap();
-        assert_eq!(format!("{:?}", ok), "#103d18".to_owned());
+        let ok = HexColor::try_from("#103d18").unwrap();
+        assert_eq!(format!("{}", ok), "#103d18".to_owned());
     }
 }

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -92,15 +92,16 @@ impl<S> TryFrom<S> for HexColor
             return Err(Error::HexColor(format!("No leading #: found `{}`", s)));
         }
 
-        let mut hex = s.clone();
         // #d18 -> #dd1188
-        if num_chars == 4 {
-            hex = s.chars().skip(1).fold(String::from("#"), |mut s, c| {
+        let hex = if num_chars == 4 {
+            s.chars().skip(1).fold(String::from("#"), |mut s, c| {
                 s.push(c);
                 s.push(c);
                 s
-            });
-        }
+            })
+        } else {
+            s.clone()
+        };
 
         // see if the remaining part of the string is actually hex
         match hex[1..].from_hex() {

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -1,17 +1,6 @@
 use error::Error;
-use rustc_serialize::hex::FromHex;
-use rustc_serialize::json::{ToJson, Json};
-use rustc_serialize::{Encodable, Encoder};
-use TryFrom;
-
-/// A `HexColor` `String` can be one of:
-///
-/// 1. `String`s: `good`, `warning`, `danger`
-/// 2. Any valid hex color code: e.g. `#b13d41` or `#000`.
-///
-/// hex color codes will be checked to ensure a valid hex number is provided
-#[derive(Debug)]
-pub struct HexColor(String);
+use hexx::FromHex;
+use {HexColor, TryFrom};
 
 impl HexColor {
     fn new<S: Into<String>>(s: S) -> HexColor {
@@ -104,7 +93,7 @@ impl<S> TryFrom<S> for HexColor
         };
 
         // see if the remaining part of the string is actually hex
-        match hex[1..].from_hex() {
+        match Vec::from_hex(&hex[1..]) {
             Ok(_) => Ok(HexColor::new(s)),
             Err(e) => Err(e.into()),
         }
@@ -119,22 +108,10 @@ impl TryFrom<SlackColor> for HexColor {
     }
 }
 
-impl ToJson for HexColor {
-    fn to_json(&self) -> Json {
-        Json::String(format!("{}", &self))
-    }
-}
-
-impl Encodable for HexColor {
-    fn encode<S: Encoder>(&self, encoder: &mut S) -> ::std::result::Result<(), S::Error> {
-        encoder.emit_str(format!("{}", &self).as_ref())
-    }
-}
-
 #[cfg(test)]
 mod test {
-    use hex::*;
-    use TryFrom;
+    use super::*;
+    use {HexColor, TryFrom};
 
     #[test]
     fn test_hex_color_too_short() {
@@ -156,8 +133,7 @@ mod test {
     fn test_hex_color_invalid_hex_fmt() {
         let err = HexColor::try_from("#abc12z").unwrap_err();
         assert_eq!(format!("{}", err),
-                   "rustc_serialize::hex::FromHexError: Invalid character 'z' at position 5"
-                       .to_owned());
+                   "hexx::FromHexError: Invalid character 'z' at position 5".to_owned());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,10 +7,8 @@
         unused_import_braces,
         unused_qualifications,
         unused_results)]
-// add feature test when testing and unstable feature is provided
-#![cfg_attr(all(test, feature = "unstable"), feature(test))]
 #![cfg_attr(test, deny(warnings))]
-#![cfg_attr(any(feature = "clippy", feature = "unstable"), allow(unstable_features))]
+#![cfg_attr(any(feature = "clippy"), allow(unstable_features))]
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]
 #![cfg_attr(feature = "clippy", deny(clippy))]
@@ -21,8 +19,6 @@
 
 #[macro_use]
 extern crate log;
-#[cfg(all(test, feature="unstable"))]
-extern crate test; // needed for benchmarking
 
 extern crate curl;
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ extern crate serde;
 extern crate serde_json;
 extern crate hex as hexx;
 pub extern crate url;
+pub extern crate chrono;
 
 include!(concat!(env!("OUT_DIR"), "/serde_types.rs"));
 
@@ -41,6 +42,8 @@ pub use hex::SlackColor;
 pub use error::{Error, Result};
 use url::Url;
 
+#[macro_use]
+mod macros;
 mod helper;
 mod error;
 mod hex;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ extern crate rustc_serialize;
 #[macro_use]
 extern crate quick_error;
 
-pub use slack::{Slack, SlackText, SlackLink};
+pub use slack::{Slack, SlackText, SlackTextContent, SlackLink};
 pub use payload::{Payload, PayloadBuilder};
 pub use attachment::{Attachment, AttachmentBuilder, Field};
 pub use hex::{SlackColor, HexColor};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,14 +30,10 @@ extern crate rustc_serialize;
 extern crate quick_error;
 
 pub use slack::{Slack, SlackText, SlackLink};
-
-pub use payload::{Payload, PayloadTemplate};
-
-pub use attachment::{Attachment, AttachmentTemplate, Field};
-
-pub use error::{Error, Result};
-
+pub use payload::{Payload, PayloadBuilder};
+pub use attachment::{Attachment, AttachmentBuilder, Field};
 pub use hex::{SlackColor, HexColor};
+pub use error::{Error, Result};
 
 mod helper;
 mod error;
@@ -45,3 +41,41 @@ mod hex;
 mod payload;
 mod attachment;
 mod slack;
+
+/// Waiting to stabilize: https://github.com/rust-lang/rust/issues/33417
+///
+/// An attempted conversion that consumes `self`, which may or may not be expensive.
+///
+/// Library authors should not directly implement this trait, but should prefer implementing
+/// the [`TryFrom`] trait, which offers greater flexibility and provides an equivalent `TryInto`
+/// implementation for free, thanks to a blanket implementation in the standard library.
+///
+/// [`TryFrom`]: trait.TryFrom.html
+pub trait TryInto<T>: Sized {
+    /// The type returned in the event of a conversion error.
+    type Err;
+
+    /// Performs the conversion.
+    fn try_into(self) -> ::std::result::Result<T, Self::Err>;
+}
+
+/// Waiting to stabilize: https://github.com/rust-lang/rust/issues/33417
+///
+/// Attempt to construct `Self` via a conversion.
+pub trait TryFrom<T>: Sized {
+    /// The type returned in the event of a conversion error.
+    type Err;
+
+    /// Performs the conversion.
+    fn try_from(T) -> ::std::result::Result<Self, Self::Err>;
+}
+
+impl<T, U> TryInto<U> for T
+    where U: TryFrom<T>
+{
+    type Err = U::Err;
+
+    fn try_into(self) -> ::std::result::Result<U, U::Err> {
+        U::try_from(self)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ extern crate quick_error;
 extern crate serde;
 extern crate serde_json;
 extern crate hex as hexx;
+pub extern crate url;
 
 include!(concat!(env!("OUT_DIR"), "/serde_types.rs"));
 
@@ -38,6 +39,7 @@ pub use payload::PayloadBuilder;
 pub use attachment::AttachmentBuilder;
 pub use hex::SlackColor;
 pub use error::{Error, Result};
+use url::Url;
 
 mod helper;
 mod error;
@@ -81,5 +83,15 @@ impl<T, U> TryInto<U> for T
 
     fn try_into(self) -> ::std::result::Result<U, U::Err> {
         U::try_from(self)
+    }
+}
+
+impl<'a> TryFrom<&'a str> for Url {
+    type Err = Error;
+    fn try_from(s: &str) -> ::std::result::Result<Self, Self::Err> {
+        match Url::parse(s) {
+            Ok(u) => Ok(u),
+            Err(e) => Err(e.into()),
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,14 +25,18 @@ extern crate log;
 extern crate test; // needed for benchmarking
 
 extern crate curl;
-extern crate rustc_serialize;
 #[macro_use]
 extern crate quick_error;
+extern crate serde;
+extern crate serde_json;
+extern crate hex as hexx;
 
-pub use slack::{Slack, SlackText, SlackTextContent, SlackLink};
-pub use payload::{Payload, PayloadBuilder};
-pub use attachment::{Attachment, AttachmentBuilder, Field};
-pub use hex::{SlackColor, HexColor};
+include!(concat!(env!("OUT_DIR"), "/serde_types.rs"));
+
+pub use slack::{Slack, SlackTextContent, SlackLink};
+pub use payload::PayloadBuilder;
+pub use attachment::AttachmentBuilder;
+pub use hex::SlackColor;
 pub use error::{Error, Result};
 
 mod helper;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,23 @@
+/// helper macro to avoid the TryInto boilerplate for builder functions
+macro_rules! url_builder_fn {
+    {
+        $(#[$meta:meta])+
+        $name:ident, $builder:ident
+    } => {
+        $(#[$meta])+
+        pub fn $name<U: TryInto<Url, Err = Error>>(self, $name: U) -> $builder {
+            match self.inner {
+                Ok(mut inner) => {
+                    match $name.try_into() {
+                        Ok(url) => {
+                            inner.$name = Some(url);
+                            $builder { inner: Ok(inner) }
+                        }
+                        Err(e) => $builder { inner: Err(e) },
+                    }
+                }
+                _ => self,
+            }
+        }
+    }
+}

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -1,37 +1,6 @@
-use slack::SlackText;
-use attachment::Attachment;
+use {Attachment, Payload, SlackText};
 use helper::bool_to_u8;
 use error::Result;
-
-/// Payload to send to slack
-/// https://api.slack.com/incoming-webhooks
-/// https://api.slack.com/methods/chat.postMessage
-#[derive(RustcEncodable, Debug, Default)]
-pub struct Payload {
-    /// text to send
-    /// despite `text` stated as required, it does not seem to be
-    pub text: Option<SlackText>,
-    /// channel to send payload to
-    /// note: if not provided, this will default to channel
-    /// setup in slack
-    pub channel: Option<String>,
-    /// username override
-    pub username: Option<String>,
-    /// specific url for icon
-    pub icon_url: Option<String>,
-    /// emjoi for icon
-    /// https://api.slack.com/methods/emoji.list
-    pub icon_emoji: Option<String>,
-    /// attachments to send
-    pub attachments: Option<Vec<Attachment>>,
-    /// whether slack will try to fetch links and create an attachment
-    /// https://api.slack.com/docs/unfurling
-    pub unfurl_links: Option<bool>,
-    /// Pass false to disable unfurling of media content
-    pub unfurl_media: Option<bool>,
-    /// find and link channel names and usernames
-    pub link_names: Option<u8>,
-}
 
 /// `PayloadBuilder` is used to build a `Payload`
 #[derive(Debug)]

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -1,4 +1,4 @@
-use {Attachment, Payload, SlackText};
+use {Attachment, Payload, SlackText, Parse};
 use helper::bool_to_u8;
 use error::Result;
 
@@ -106,6 +106,17 @@ impl PayloadBuilder {
         match self.inner {
             Ok(mut inner) => {
                 inner.link_names = Some(bool_to_u8(b));
+                PayloadBuilder { inner: Ok(inner) }
+            }
+            _ => self,
+        }
+    }
+
+    /// Change how messages are treated.
+    pub fn parse(self, p: Parse) -> PayloadBuilder {
+        match self.inner {
+            Ok(mut inner) => {
+                inner.parse = Some(p);
                 PayloadBuilder { inner: Ok(inner) }
             }
             _ => self,

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -65,20 +65,9 @@ impl PayloadBuilder {
         }
     }
 
-    /// Set the icon_url
-    pub fn icon_url<U: TryInto<Url, Err = Error>>(self, icon_url: U) -> PayloadBuilder {
-        match self.inner {
-            Ok(mut inner) => {
-                match icon_url.try_into() {
-                    Ok(url) => {
-                        inner.icon_url = Some(url);
-                        PayloadBuilder { inner: Ok(inner) }
-                    }
-                    Err(e) => PayloadBuilder { inner: Err(e) },
-                }
-            }
-            _ => self,
-        }
+    url_builder_fn! {
+        /// Set the icon_url
+        icon_url, PayloadBuilder
     }
 
     /// Set the attachments

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -130,6 +130,9 @@ impl PayloadBuilder {
     }
 
     /// Find and link channel names and usernames.
+    // NOTE: The Slack API doesn't seem to actually require setting `link_names` to 1, any value
+    // seems to work. However, to be faithful to their spec, we will keep the `bool_to_u8` fn
+    // around.
     pub fn link_names(self, b: bool) -> PayloadBuilder {
         match self.inner {
             Ok(mut inner) => {

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -1,6 +1,7 @@
-use {Attachment, Payload, SlackText, Parse};
+use {Attachment, Payload, SlackText, Parse, TryInto};
 use helper::bool_to_u8;
-use error::Result;
+use error::{Error, Result};
+use url::Url;
 
 /// `PayloadBuilder` is used to build a `Payload`
 #[derive(Debug)]
@@ -59,6 +60,22 @@ impl PayloadBuilder {
             Ok(mut inner) => {
                 inner.icon_emoji = Some(icon_emoji.into());
                 PayloadBuilder { inner: Ok(inner) }
+            }
+            _ => self,
+        }
+    }
+
+    /// Set the icon_url
+    pub fn icon_url<U: TryInto<Url, Err = Error>>(self, icon_url: U) -> PayloadBuilder {
+        match self.inner {
+            Ok(mut inner) => {
+                match icon_url.try_into() {
+                    Ok(url) => {
+                        inner.icon_url = Some(url);
+                        PayloadBuilder { inner: Ok(inner) }
+                    }
+                    Err(e) => PayloadBuilder { inner: Err(e) },
+                }
             }
             _ => self,
         }

--- a/src/serde_types.in.rs
+++ b/src/serde_types.in.rs
@@ -1,0 +1,90 @@
+/// Representation of any text sent through slack
+/// the text must be processed to escape specific characters
+#[derive(Serialize, Debug, Default, Clone)]
+pub struct SlackText(String);
+
+/// A `HexColor` `String` can be one of:
+///
+/// 1. `String`s: `good`, `warning`, `danger`
+/// 2. Any valid hex color code: e.g. `#b13d41` or `#000`.
+///
+/// hex color codes will be checked to ensure a valid hex number is provided
+#[derive(Serialize, Debug)]
+pub struct HexColor(String);
+
+/// Slack allows for attachments to be added to messages. See
+/// https://api.slack.com/docs/attachments for more information.
+#[derive(Serialize, Debug, Default)]
+pub struct Attachment {
+    /// Required text for attachment.
+    /// Slack will use this text to display on devices that don't support markup.
+    pub fallback: SlackText,
+    /// Optional text for other devices, markup supported
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<SlackText>,
+    /// Optional text that appears above attachment
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pretext: Option<SlackText>,
+    /// Optional color of attachment
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color: Option<HexColor>,
+    /// Fields are defined as an array, and hashes contained within it will be
+    /// displayed in a table inside the message attachment.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fields: Option<Vec<Field>>,
+}
+
+/// Fields are defined as an array, and hashes contained within it will
+/// be displayed in a table inside the message attachment.
+#[derive(Serialize, Debug)]
+pub struct Field {
+    /// Shown as a bold heading above the value text.
+    /// It cannot contain markup and will be escaped for you.
+    pub title: String,
+    /// The text value of the field. It may contain standard message markup
+    /// and must be escaped as normal. May be multi-line.
+    pub value: SlackText,
+    /// An optional flag indicating whether the value is short enough to be
+    /// displayed side-by-side with other values.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub short: Option<bool>,
+}
+
+/// Payload to send to slack
+/// https://api.slack.com/incoming-webhooks
+/// https://api.slack.com/methods/chat.postMessage
+#[derive(Serialize, Debug, Default)]
+pub struct Payload {
+    /// text to send
+    /// despite `text` stated as required, it does not seem to be
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<SlackText>,
+    /// channel to send payload to
+    /// note: if not provided, this will default to channel
+    /// setup in slack
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub channel: Option<String>,
+    /// username override
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub username: Option<String>,
+    /// specific url for icon
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_url: Option<String>,
+    /// emjoi for icon
+    /// https://api.slack.com/methods/emoji.list
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_emoji: Option<String>,
+    /// attachments to send
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attachments: Option<Vec<Attachment>>,
+    /// whether slack will try to fetch links and create an attachment
+    /// https://api.slack.com/docs/unfurling
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unfurl_links: Option<bool>,
+    /// Pass false to disable unfurling of media content
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unfurl_media: Option<bool>,
+    /// find and link channel names and usernames
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub link_names: Option<u8>,
+}

--- a/src/serde_types.in.rs
+++ b/src/serde_types.in.rs
@@ -1,4 +1,5 @@
 use serde::{Serialize, Serializer};
+use chrono::NaiveDateTime;
 
 /// Representation of any text sent through slack
 /// the text must be processed to escape specific characters
@@ -34,6 +35,59 @@ pub struct Attachment {
     /// displayed in a table inside the message attachment.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fields: Option<Vec<Field>>,
+    /// Optional small text used to display the author's name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author_name: Option<SlackText>,
+    /// Optional URL that will hyperlink the `author_name` text mentioned above. Will only
+    /// work if `author_name` is present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author_link: Option<Url>,
+    /// Optional URL that displays a small 16x16px image to the left of
+    /// the `author_name` text. Will only work if `author_name` is present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author_icon: Option<Url>,
+    /// Optional larger, bolder text above the main body
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<SlackText>,
+    /// Optional URL to link to from the title
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title_link: Option<Url>,
+    /// Optional URL to an image that will be displayed in the body
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image_url: Option<Url>,
+    /// Optional URL to an image that will be displayed as a thumbnail to the
+    /// right of the body
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thumb_url: Option<Url>,
+    /// Optional text that will appear at the bottom of the attachment
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub footer: Option<SlackText>,
+    /// Optional URL to an image that will be displayed at the bottom of the
+    /// attachment
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub footer_icon: Option<Url>,
+    /// Optional timestamp to be displayed with the attachment
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ts: Option<SlackTime>,
+}
+
+/// Slack timestamp
+#[derive(Debug)]
+pub struct SlackTime(NaiveDateTime);
+
+impl SlackTime {
+    /// Construct a new `SlackTime`
+    pub fn new(time: &NaiveDateTime) -> SlackTime {
+        SlackTime(time.clone())
+    }
+}
+
+impl Serialize for SlackTime {
+    fn serialize<S>(&self, serializer: &mut S) -> ::std::result::Result<(), S::Error>
+        where S: Serializer
+    {
+        serializer.serialize_i64(self.0.timestamp())
+    }
 }
 
 /// Fields are defined as an array, and hashes contained within it will

--- a/src/serde_types.in.rs
+++ b/src/serde_types.in.rs
@@ -1,3 +1,5 @@
+use serde::{Serialize, Serializer};
+
 /// Representation of any text sent through slack
 /// the text must be processed to escape specific characters
 #[derive(Serialize, Debug, Default, Clone)]
@@ -87,4 +89,28 @@ pub struct Payload {
     /// find and link channel names and usernames
     #[serde(skip_serializing_if = "Option::is_none")]
     pub link_names: Option<u8>,
+    /// Change how messages are treated.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parse: Option<Parse>,
+}
+
+/// Change how messages are treated.
+#[derive(Debug)]
+pub enum Parse {
+    /// Full
+    Full,
+    /// None
+    None,
+}
+
+impl Serialize for Parse {
+    fn serialize<S>(&self, serializer: &mut S) -> ::std::result::Result<(), S::Error>
+        where S: Serializer
+    {
+        let st = match *self {
+            Parse::Full => "full",
+            Parse::None => "none",
+        };
+        serializer.serialize_str(st)
+    }
 }

--- a/src/serde_types.in.rs
+++ b/src/serde_types.in.rs
@@ -71,7 +71,7 @@ pub struct Payload {
     pub username: Option<String>,
     /// specific url for icon
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub icon_url: Option<String>,
+    pub icon_url: Option<Url>,
     /// emjoi for icon
     /// https://api.slack.com/methods/emoji.list
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -156,7 +156,7 @@ mod test {
     #[cfg(feature = "unstable")]
     use test::Bencher;
     use slack::{Slack, SlackLink};
-    use {PayloadBuilder, AttachmentBuilder, Field, SlackText, serde_json};
+    use {PayloadBuilder, AttachmentBuilder, Field, SlackText, Parse, serde_json};
 
     #[test]
     fn slack_incoming_url_test() {
@@ -208,10 +208,11 @@ mod test {
             .attachments(a)
             .unfurl_links(false)
             .link_names(true)
+            .parse(Parse::Full)
             .build()
             .unwrap();
 
-        assert_eq!(serde_json::to_string(&p).unwrap().to_owned(), r##"{"text":"test message","channel":"#abc","username":"Bot","icon_emoji":":chart_with_upwards_trend:","attachments":[{"fallback":"fallback &lt;&amp;&gt;","text":"text &lt;&amp;&gt;","color":"#6800e8","fields":[{"title":"title","value":"value"}]}],"unfurl_links":false,"link_names":1}"##.to_owned())
+        assert_eq!(serde_json::to_string(&p).unwrap().to_owned(), r##"{"text":"test message","channel":"#abc","username":"Bot","icon_emoji":":chart_with_upwards_trend:","attachments":[{"fallback":"fallback &lt;&amp;&gt;","text":"text &lt;&amp;&gt;","color":"#6800e8","fields":[{"title":"title","value":"value"}]}],"unfurl_links":false,"link_names":1,"parse":"full"}"##.to_owned())
     }
 
     #[test]

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -80,6 +80,12 @@ impl<'a> From<&'a str> for SlackText {
     }
 }
 
+impl<'a> From<String> for SlackText {
+    fn from(s: String) -> SlackText {
+        SlackText::new(s)
+    }
+}
+
 /// Enum used for constructing a text field having both `SlackText`(s) and `SlackLink`(s). The
 /// variants should be used together in a `Vec` on any function having a `Into<SlackText>` trait
 /// bound. The combined text will be space-separated.

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -123,7 +123,10 @@ impl ::std::fmt::Display for SlackText {
 /// Representation of a link sent in slack
 #[derive(Debug)]
 pub struct SlackLink {
-    /// URL for link
+    /// URL for link.
+    ///
+    /// NOTE: this is NOT a `Url` type because some of the slack "urls", don't conform to standard
+    /// url parsing scheme, which are enforced by the `url` crate.
     pub url: String,
     /// Anchor text for link
     pub text: SlackText,
@@ -159,6 +162,7 @@ mod test {
     use test::Bencher;
     use slack::{Slack, SlackLink};
     use {PayloadBuilder, AttachmentBuilder, Field, SlackText, Parse, serde_json};
+    use chrono::NaiveDateTime;
 
     #[test]
     fn slack_incoming_url_test() {
@@ -199,6 +203,8 @@ mod test {
                          .text("text <&>")
                          .color("#6800e8")
                          .fields(vec![Field::new("title", "value", None)])
+                         .title_link("https://title_link.com/")
+                         .ts(&NaiveDateTime::from_timestamp(123456789, 0))
                          .build()
                          .unwrap()];
 
@@ -215,7 +221,7 @@ mod test {
             .build()
             .unwrap();
 
-        assert_eq!(serde_json::to_string(&p).unwrap().to_owned(), r##"{"text":"test message","channel":"#abc","username":"Bot","icon_url":"https://example.com/","icon_emoji":":chart_with_upwards_trend:","attachments":[{"fallback":"fallback &lt;&amp;&gt;","text":"text &lt;&amp;&gt;","color":"#6800e8","fields":[{"title":"title","value":"value"}]}],"unfurl_links":false,"link_names":1,"parse":"full"}"##.to_owned())
+        assert_eq!(serde_json::to_string(&p).unwrap().to_owned(), r##"{"text":"test message","channel":"#abc","username":"Bot","icon_url":"https://example.com/","icon_emoji":":chart_with_upwards_trend:","attachments":[{"fallback":"fallback &lt;&amp;&gt;","text":"text &lt;&amp;&gt;","color":"#6800e8","fields":[{"title":"title","value":"value"}],"title_link":"https://title_link.com/","ts":123456789}],"unfurl_links":false,"link_names":1,"parse":"full"}"##.to_owned())
     }
 
     #[test]

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -243,11 +243,4 @@ mod test {
         assert_eq!(format!("{}", st),
                    "moo &lt;&amp;&gt; moo <@USER|M&lt;E&gt;> wow.");
     }
-
-    #[cfg(feature = "unstable")]
-    #[bench]
-    fn bench_get_escaped_text(b: &mut Bencher) {
-        let st = SlackText::new("moo <&> moo");
-        b.iter(|| st.get_escaped_text())
-    }
 }


### PR DESCRIPTION
- Use builder pattern for `Attachment` and `Payload`.
- Use `Url` type where appropriate.
- Use idiomatic rust conversions where appropriate.
- Replace `rustc_serialize` with `serde` to eliminate extraneous fields from being sent to slack.
- Support three character hex codes
- Add a CHANGELOG

[breaking-change]