### PR TITLE
Upgrade curl to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ chrono = "0.2.25"
 
 [dependencies]
 chrono = "0.2.25"
-curl = "0.3.0"
+curl = ">= 0.3.0, < 0.5.0"
 hex = "0.2.0"
 log = "0.3.6"
 quick-error = "1.1.0"


### PR DESCRIPTION
This avoids version conflicts when combined with the `git2` crate, which requires newer `curl-sys`.

Looks like there are no breaking changes in `curl` 0.4 that affect `slack-hook`.