### PR TITLE
Content-Type header should be set to application/json

### DIFF
--- a/src/slack.rs
+++ b/src/slack.rs
@@ -1,4 +1,4 @@
-use curl::easy::Easy;
+use curl::easy::{Easy,List};
 use std::str;
 use error::{Result, Error};
 use {Payload, TryInto, serde_json};
@@ -30,6 +30,9 @@ impl Slack {
         try!(easy.url(&self.incoming_url[..]));
 
         try!(easy.post(true));
+        let mut headers = List::new();
+        try!(headers.append("Content-Type: application/json"));
+        try!(easy.http_headers(headers));
         try!(easy.post_fields_copy(encoded.as_bytes()));
         let mut data = Vec::new();
         {


### PR DESCRIPTION
Slack and Mattermost expect the Content-Type header to be
application/json if the payload is JSON.

See https://api.slack.com/incoming-webhooks section "Send it directly in
JSON" for Slack and
https://docs.mattermost.com/developer/webhooks-incoming.html#creating-integrations-using-incoming-webhooks
under "Additional Notes" 1.