### PR TITLE
Add support for the `mrkdwn_in` field inside attachments.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/frostly/rust-slack"
 version = "0.4.0"
 
 [dependencies]
-chrono = "0.3.1"
+chrono = "0.4"
 curl = ">= 0.3.0, < 0.5.0"
 hex = "0.2.0"
 log = "0.3.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ serde = "1"
 serde_derive = "1"
 serde_json = "1"
 url_serde = "0.2"
-url = ">= 1.2.0, < 1.5.0"
+url = ">= 1.2.0, <= 1.5"
 
 [dependencies.clippy]
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ serde = "1"
 serde_derive = "1"
 serde_json = "1"
 url_serde = "0.2"
-url = ">= 1.2.0, <= 1.5"
+url = ">= 1.2.0, < 1.6"
 
 [dependencies.clippy]
 optional = true

--- a/src/attachment.rs
+++ b/src/attachment.rs
@@ -74,10 +74,8 @@ pub struct Attachment {
 pub enum Section {
     /// The pretext section.
     Pretext,
-
     /// The text section.
     Text,
-
     /// The fields.
     Fields,
 }
@@ -258,7 +256,6 @@ impl AttachmentBuilder {
             _ => self,
         }
     }
-
 
     /// Optional sections formatted as markdown.
     pub fn markdown_in<'a, I: IntoIterator<Item = &'a Section>>(self, sections: I) -> AttachmentBuilder {

--- a/src/attachment.rs
+++ b/src/attachment.rs
@@ -63,6 +63,23 @@ pub struct Attachment {
     /// Optional timestamp to be displayed with the attachment
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ts: Option<SlackTime>,
+    /// Optional sections formatted as markdown.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mrkdwn_in: Option<Vec<Section>>,
+}
+
+/// Sections define parts of an attachment.
+#[derive(Eq, PartialEq, Copy, Clone, Serialize, Debug)]
+#[serde(rename_all = "lowercase")]
+pub enum Section {
+    /// The pretext section.
+    Pretext,
+
+    /// The text section.
+    Text,
+
+    /// The fields.
+    Fields,
 }
 
 /// Fields are defined as an array, and hashes contained within it will
@@ -239,6 +256,18 @@ impl AttachmentBuilder {
                 AttachmentBuilder { inner: Ok(inner) }
             }
             _ => self,
+        }
+    }
+
+
+    /// Optional sections formatted as markdown.
+    pub fn markdown_in<'a, I: IntoIterator<Item = &'a Section>>(self, sections: I) -> AttachmentBuilder {
+        match self.inner {
+            Ok(mut inner) => {
+                inner.mrkdwn_in = Some(sections.into_iter().cloned().collect());
+                AttachmentBuilder { inner: Ok(inner) }
+            }
+            _ => self
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub extern crate chrono;
 
 pub use slack::{Slack, SlackTextContent, SlackLink, SlackText, SlackTime};
 pub use payload::{Payload, PayloadBuilder, Parse};
-pub use attachment::{Attachment, AttachmentBuilder, Field};
+pub use attachment::{Attachment, AttachmentBuilder, Section, Field};
 pub use hex::{HexColor, SlackColor};
 pub use error::{Error, Result};
 use url::Url;


### PR DESCRIPTION
Needed this to make formatted attachments, also had to bump some dependencies to get it to play nice with the semver compatibility, hope that's okay.