### PR TITLE
add status code to slack error

### DIFF
--- a/src/slack.rs
+++ b/src/slack.rs
@@ -29,7 +29,7 @@ impl Slack {
         if response.status() == StatusCode::Ok {
             Ok(())
         } else {
-            Err(ErrorKind::Slack("HTTP error".to_string()).into())
+            Err(ErrorKind::Slack(format!("HTTP error {}", response.status())).into())
         }
     }
 }


### PR DESCRIPTION
Just trying to make the error more obvious.
It's easier to point at people when there's a 404 in the logs and say, hey, you probably got the wrong hook url :-)

Thanks for this crate btw, it's very nice :-)