### PR TITLE
bump reqwest for openssl build issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.7.0"
 
 [dependencies]
 chrono = "0.4"
-reqwest = "0.7"
+reqwest = "0.9"
 hex = "0.2.0"
 error-chain = "~0.11"
 serde = "1"

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -1,6 +1,6 @@
 use chrono::NaiveDateTime;
 use error::{Error, ErrorKind, Result};
-use reqwest::{Client, StatusCode, Url};
+use reqwest::{Client, Url};
 use serde::{Serialize, Serializer};
 use std::fmt;
 use {Payload, TryInto};
@@ -17,15 +17,15 @@ impl Slack {
     pub fn new<T: TryInto<Url, Err = Error>>(hook: T) -> Result<Slack> {
         Ok(Slack {
             hook: hook.try_into()?,
-            client: Client::new()?,
+            client: Client::new(),
         })
     }
 
     /// Send payload to slack service
     pub fn send(&self, payload: &Payload) -> Result<()> {
-        let response = self.client.post(self.hook.clone())?.json(payload)?.send()?;
+        let response = self.client.post(self.hook.clone()).json(payload).send()?;
 
-        if response.status() == StatusCode::Ok {
+        if response.status().is_success(){
             Ok(())
         } else {
             Err(ErrorKind::Slack(format!("HTTP error {}", response.status())).into())


### PR DESCRIPTION
old reqwest pulls in an openssl version that is no longer compatible my system.

the whole ecosystem seems to be propagating fixes for https://github.com/sfackler/rust-openssl/issues/987 as a consequence.

have upgraded reqwests and fixed the few api incompatibilities herein.