### PR TITLE
Chore fix styling

### DIFF
--- a/src/attachment.rs
+++ b/src/attachment.rs
@@ -101,7 +101,7 @@ pub struct Action {
     pub style: Option<String>,
     /// Value of action
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub value: Option<String>
+    pub value: Option<String>,
 }
 
 impl Action {
@@ -111,15 +111,14 @@ impl Action {
         text: S,
         name: S,
         style: Option<String>,
-        value: Option<String>
-
+        value: Option<String>,
     ) -> Action {
         Action {
             action_type: action_type.into(),
             text: text.into(),
             name: name.into(),
             style,
-            value
+            value,
         }
     }
 }

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -81,7 +81,8 @@ where
                 "Must be 4 or 7 characters long (including #): \
                  found `{}`",
                 s
-            )).into());
+            ))
+            .into());
         }
         if !s.starts_with('#') {
             return Err(ErrorKind::HexColor(format!("No leading #: found `{}`", s)).into());
@@ -141,10 +142,9 @@ mod test {
     #[test]
     fn test_hex_color_invalid_hex_fmt() {
         let err = HexColor::try_from("#abc12z").unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("Invalid character 'z' at position 5")
-        );
+        assert!(err
+            .to_string()
+            .contains("Invalid character 'z' at position 5"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,14 @@
-#![deny(missing_docs, missing_debug_implementations, trivial_casts, trivial_numeric_casts,
-       unsafe_code, unstable_features, unused_import_braces, unused_qualifications, unused_results)]
+#![deny(
+    missing_docs,
+    missing_debug_implementations,
+    trivial_casts,
+    trivial_numeric_casts,
+    unsafe_code,
+    unstable_features,
+    unused_import_braces,
+    unused_qualifications,
+    unused_results
+)]
 #![cfg_attr(test, deny(warnings))]
 
 //! Library to send messages to slack rooms
@@ -18,19 +27,19 @@ extern crate serde_derive;
 extern crate serde_json;
 extern crate url_serde;
 
-pub use slack::{Slack, SlackLink, SlackUserLink, SlackText, SlackTextContent, SlackTime};
-pub use payload::{Parse, Payload, PayloadBuilder};
-pub use attachment::{Attachment, AttachmentBuilder, Field, Section, Action};
-pub use hex::{HexColor, SlackColor};
+pub use attachment::{Action, Attachment, AttachmentBuilder, Field, Section};
 pub use error::{Error, Result};
+pub use hex::{HexColor, SlackColor};
+pub use payload::{Parse, Payload, PayloadBuilder};
+pub use slack::{Slack, SlackLink, SlackText, SlackTextContent, SlackTime, SlackUserLink};
 
 #[macro_use]
 mod macros;
-mod helper;
+mod attachment;
 mod error;
+mod helper;
 mod hex;
 mod payload;
-mod attachment;
 mod slack;
 
 /// Waiting to stabilize: https://github.com/rust-lang/rust/issues/33417

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ pub trait TryFrom<T>: Sized {
     type Err;
 
     /// Performs the conversion.
-    fn try_from(T) -> ::std::result::Result<Self, Self::Err>;
+    fn try_from(_: T) -> ::std::result::Result<Self, Self::Err>;
 }
 
 impl<T, U> TryInto<U> for T

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -1,8 +1,8 @@
-use {Attachment, SlackText, TryInto};
-use helper::bool_to_u8;
 use error::{Error, Result};
-use serde::{Serialize, Serializer};
+use helper::bool_to_u8;
 use reqwest::Url;
+use serde::{Serialize, Serializer};
+use {Attachment, SlackText, TryInto};
 
 /// Payload to send to slack
 /// https://api.slack.com/incoming-webhooks

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -239,7 +239,7 @@ mod test {
             url: "http://google.com".to_owned(),
         };
         assert_eq!(
-            serde_json::to_string(&s).unwrap().to_owned(),
+            serde_json::to_string(&s).unwrap(),
             "\"<http://google.com|moo &lt;&amp;&gt; moo>\"".to_owned()
         )
     }
@@ -268,7 +268,7 @@ mod test {
             .build()
             .unwrap();
 
-        assert_eq!(serde_json::to_string(&p).unwrap().to_owned(),
+        assert_eq!(serde_json::to_string(&p).unwrap(),
             r##"{"text":"test message","channel":"#abc","username":"Bot","icon_url":"https://example.com/","icon_emoji":":chart_with_upwards_trend:","attachments":[{"fallback":"fallback &lt;&amp;&gt;","text":"text &lt;&amp;&gt;","color":"#6800e8","fields":[{"title":"title","value":"value"}],"title_link":"https://title_link.com/","ts":123456789}],"unfurl_links":false,"link_names":1,"parse":"full"}"##.to_owned())
     }
 
@@ -277,7 +277,7 @@ mod test {
         let p = PayloadBuilder::new().text("test message").build().unwrap();
 
         assert_eq!(
-            serde_json::to_string(&p).unwrap().to_owned(),
+            serde_json::to_string(&p).unwrap(),
             r##"{"text":"test message"}"##.to_owned()
         )
     }

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -25,7 +25,7 @@ impl Slack {
     pub fn send(&self, payload: &Payload) -> Result<()> {
         let response = self.client.post(self.hook.clone()).json(payload).send()?;
 
-        if response.status().is_success(){
+        if response.status().is_success() {
             Ok(())
         } else {
             Err(ErrorKind::Slack(format!("HTTP error {}", response.status())).into())
@@ -113,7 +113,8 @@ impl<'a> From<&'a [SlackTextContent]> for SlackText {
                 SlackTextContent::Text(ref s) => format!("{}", s),
                 SlackTextContent::Link(ref link) => format!("{}", link),
                 SlackTextContent::User(ref u) => format!("{}", u),
-            }).collect::<Vec<String>>()
+            })
+            .collect::<Vec<String>>()
             .join(" ");
         SlackText::new_raw(st)
     }
@@ -245,16 +246,14 @@ mod test {
 
     #[test]
     fn json_complete_payload_test() {
-        let a = vec![
-            AttachmentBuilder::new("fallback <&>")
-                .text("text <&>")
-                .color("#6800e8")
-                .fields(vec![Field::new("title", "value", None)])
-                .title_link("https://title_link.com/")
-                .ts(&NaiveDateTime::from_timestamp(123_456_789, 0))
-                .build()
-                .unwrap(),
-        ];
+        let a = vec![AttachmentBuilder::new("fallback <&>")
+            .text("text <&>")
+            .color("#6800e8")
+            .fields(vec![Field::new("title", "value", None)])
+            .title_link("https://title_link.com/")
+            .ts(&NaiveDateTime::from_timestamp(123_456_789, 0))
+            .build()
+            .unwrap()];
 
         let p = PayloadBuilder::new()
             .text("test message")


### PR DESCRIPTION
These changes just run `cargo fmt` and `cargo clippy --fix` on the repo. There are still some failing warnings due to deprecations with the old `Error` usage, but those can be handled later