### PR TITLE
Update to 2018 edition

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -63,4 +63,6 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          # FIXME: currently `error_chain` causes some deprecation warnings, so
+          # temporaily allow warnings until that gets sorted out
+          # args: -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ name = "slack-hook"
 readme = "README.md"
 repository = "https://github.com/frostly/rust-slack"
 version = "0.8.0"
+edition = "2018"
 
 [dependencies]
 chrono = "0.4"

--- a/src/attachment.rs
+++ b/src/attachment.rs
@@ -1,7 +1,7 @@
 use chrono::NaiveDateTime;
-use error::{Error, Result};
+use crate::error::{Error, Result};
 use reqwest::Url;
-use {HexColor, SlackText, SlackTime, TryInto};
+use crate::{HexColor, SlackText, SlackTime, TryInto};
 
 /// Slack allows for attachments to be added to messages. See
 /// https://api.slack.com/docs/attachments for more information.

--- a/src/attachment.rs
+++ b/src/attachment.rs
@@ -1,8 +1,9 @@
 use crate::error::{Error, Result};
-use crate::{HexColor, SlackText, SlackTime, TryInto};
+use crate::{HexColor, SlackText, SlackTime};
 use chrono::NaiveDateTime;
 use reqwest::Url;
 use serde::Serialize;
+use std::convert::TryInto;
 
 /// Slack allows for attachments to be added to messages. See
 /// https://api.slack.com/docs/attachments for more information.
@@ -193,7 +194,7 @@ impl AttachmentBuilder {
     /// 3. Any valid hex color code: e.g. `#b13d41` or `#000`.
     ///
     /// hex color codes will be checked to ensure a valid hex number is provided
-    pub fn color<C: TryInto<HexColor, Err = Error>>(self, color: C) -> AttachmentBuilder {
+    pub fn color<C: TryInto<HexColor, Error = Error>>(self, color: C) -> AttachmentBuilder {
         match self.inner {
             Ok(mut inner) => match color.try_into() {
                 Ok(c) => {

--- a/src/attachment.rs
+++ b/src/attachment.rs
@@ -1,7 +1,8 @@
-use chrono::NaiveDateTime;
 use crate::error::{Error, Result};
-use reqwest::Url;
 use crate::{HexColor, SlackText, SlackTime, TryInto};
+use chrono::NaiveDateTime;
+use reqwest::Url;
+use serde::Serialize;
 
 /// Slack allows for attachments to be added to messages. See
 /// https://api.slack.com/docs/attachments for more information.

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@ error_chain! {
     foreign_links {
         Utf8(::std::str::Utf8Error) #[doc = "utf8 error, slack responses should be valid utf8"];
         Serialize(::serde_json::error::Error) #[doc = "`serde_json::error::Error`"];
-        FromHex(::hexx::FromHexError) #[doc = "`rustc_serialize::hex::FromHexError`"];
+        FromHex(crate::hexx::FromHexError) #[doc = "`rustc_serialize::hex::FromHexError`"];
         Reqwest(::reqwest::Error) #[doc = "`reqwest::Error`"];
         Url(::reqwest::UrlError) #[doc = "`reqwest::UrlError`"];
         Io(::std::io::Error) #[doc = "`std::io::Error`"];

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,12 @@
 error_chain! {
+    types {
+        Error, ErrorKind, ResultExt, Result;
+    }
+
     foreign_links {
         Utf8(::std::str::Utf8Error) #[doc = "utf8 error, slack responses should be valid utf8"];
         Serialize(::serde_json::error::Error) #[doc = "`serde_json::error::Error`"];
-        FromHex(crate::hexx::FromHexError) #[doc = "`rustc_serialize::hex::FromHexError`"];
+        FromHex(::hex::FromHexError) #[doc = "`rustc_serialize::hex::FromHexError`"];
         Reqwest(::reqwest::Error) #[doc = "`reqwest::Error`"];
         Url(::reqwest::UrlError) #[doc = "`reqwest::UrlError`"];
         Io(::std::io::Error) #[doc = "`std::io::Error`"];

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -1,7 +1,0 @@
-pub fn bool_to_u8(b: bool) -> u8 {
-    if b {
-        1u8
-    } else {
-        0u8
-    }
-}

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -1,6 +1,6 @@
-use error::{Error, ErrorKind};
-use hexx::FromHex;
-use TryFrom;
+use crate::error::{Error, ErrorKind};
+use crate::hexx::FromHex;
+use crate::TryFrom;
 
 /// A `HexColor` `String` can be one of:
 ///
@@ -118,7 +118,7 @@ impl TryFrom<SlackColor> for HexColor {
 #[cfg(test)]
 mod test {
     use super::*;
-    use {HexColor, TryFrom};
+    use crate::{HexColor, TryFrom};
 
     #[test]
     fn test_hex_color_too_short() {

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -123,7 +123,7 @@ mod test {
 
     #[test]
     fn test_hex_color_too_short() {
-        let err = HexColor::from_str("abc").unwrap_err();
+        let err = HexColor::try_from("abc").unwrap_err();
         assert_eq!(
             err.to_string(),
             "hex color parsing error: Must be 4 or 7 characters long (including #): found \
@@ -133,7 +133,7 @@ mod test {
 
     #[test]
     fn test_hex_color_missing_hash() {
-        let err = HexColor::from_str("1234567").unwrap_err();
+        let err = HexColor::try_from("1234567").unwrap_err();
         assert_eq!(
             err.to_string(),
             "hex color parsing error: No leading #: found `1234567`"
@@ -142,7 +142,7 @@ mod test {
 
     #[test]
     fn test_hex_color_invalid_hex_fmt() {
-        let err = HexColor::from_str("#abc12z").unwrap_err();
+        let err = HexColor::try_from("#abc12z").unwrap_err();
         assert!(err
             .to_string()
             .contains("Invalid character 'z' at position 5"));
@@ -150,31 +150,31 @@ mod test {
 
     #[test]
     fn test_hex_color_good() {
-        let h: HexColor = HexColor::from_str(&SlackColor::Good.to_string()).unwrap();
+        let h: HexColor = HexColor::try_from(SlackColor::Good).unwrap();
         assert_eq!(h.to_string(), "good");
     }
 
     #[test]
     fn test_hex_color_danger_str() {
-        let ok = HexColor::from_str("danger").unwrap();
+        let ok = HexColor::try_from("danger").unwrap();
         assert_eq!(ok.to_string(), "danger");
     }
 
     #[test]
     fn test_hex_color_3_char_hex() {
-        let ok = HexColor::from_str("#d18").unwrap();
+        let ok = HexColor::try_from("#d18").unwrap();
         assert_eq!(ok.to_string(), "#d18");
     }
 
     #[test]
     fn test_hex_color_valid_upper_hex() {
-        let ok = HexColor::from_str("#103D18").unwrap();
+        let ok = HexColor::try_from("#103D18").unwrap();
         assert_eq!(ok.to_string(), "#103D18");
     }
 
     #[test]
     fn test_hex_color_valid_lower_hex() {
-        let ok = HexColor::from_str("#103d18").unwrap();
+        let ok = HexColor::try_from("#103d18").unwrap();
         assert_eq!(ok.to_string(), "#103d18");
     }
 }

--- a/src/hexx.rs
+++ b/src/hexx.rs
@@ -1,6 +1,8 @@
 use crate::error::{Error, ErrorKind};
-use crate::hexx::FromHex;
 use crate::TryFrom;
+
+use hex::FromHex;
+use serde::Serialize;
 
 /// A `HexColor` `String` can be one of:
 ///

--- a/src/hexx.rs
+++ b/src/hexx.rs
@@ -25,7 +25,7 @@ impl Default for HexColor {
 }
 
 impl ::std::fmt::Display for HexColor {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         write!(f, "{}", self.0)
     }
 }
@@ -45,7 +45,7 @@ pub enum SlackColor {
 const SLACK_COLORS: [&str; 3] = ["good", "warning", "danger"];
 
 impl ::std::fmt::Display for SlackColor {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         write!(f, "{}", self.as_ref())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ extern crate error_chain;
 
 pub use crate::attachment::{Action, Attachment, AttachmentBuilder, Field, Section};
 pub use crate::error::{Error, Result};
-pub use crate::hexx::{HexColor, SlackColor};
+pub use crate::hex::{HexColor, SlackColor};
 pub use crate::payload::{Parse, Payload, PayloadBuilder};
 pub use crate::slack::{Slack, SlackLink, SlackText, SlackTextContent, SlackTime, SlackUserLink};
 
@@ -29,6 +29,6 @@ mod macros;
 
 mod attachment;
 mod error;
-mod hexx;
+mod hex;
 mod payload;
 mod slack;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,35 +9,26 @@
     unused_qualifications,
     unused_results
 )]
-#![cfg_attr(test, deny(warnings))]
 
 //! Library to send messages to slack rooms
 //! supports entire messaging API, including attachments and fields
 //! also support for built-in colors as well as any hex colors
 
-extern crate reqwest;
-
-extern crate chrono;
 #[macro_use]
 extern crate error_chain;
-extern crate hex as hexx;
-extern crate serde;
-#[macro_use]
-extern crate serde_derive;
-extern crate serde_json;
-extern crate url_serde;
 
 pub use crate::attachment::{Action, Attachment, AttachmentBuilder, Field, Section};
 pub use crate::error::{Error, Result};
-pub use crate::hex::{HexColor, SlackColor};
+pub use crate::hexx::{HexColor, SlackColor};
 pub use crate::payload::{Parse, Payload, PayloadBuilder};
 pub use crate::slack::{Slack, SlackLink, SlackText, SlackTextContent, SlackTime, SlackUserLink};
 
 #[macro_use]
 mod macros;
+
 mod attachment;
 mod error;
-mod hex;
+mod hexx;
 mod payload;
 mod slack;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,11 +27,11 @@ extern crate serde_derive;
 extern crate serde_json;
 extern crate url_serde;
 
-pub use attachment::{Action, Attachment, AttachmentBuilder, Field, Section};
-pub use error::{Error, Result};
-pub use hex::{HexColor, SlackColor};
-pub use payload::{Parse, Payload, PayloadBuilder};
-pub use slack::{Slack, SlackLink, SlackText, SlackTextContent, SlackTime, SlackUserLink};
+pub use crate::attachment::{Action, Attachment, AttachmentBuilder, Field, Section};
+pub use crate::error::{Error, Result};
+pub use crate::hex::{HexColor, SlackColor};
+pub use crate::payload::{Parse, Payload, PayloadBuilder};
+pub use crate::slack::{Slack, SlackLink, SlackText, SlackTextContent, SlackTime, SlackUserLink};
 
 #[macro_use]
 mod macros;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,6 @@ pub use crate::slack::{Slack, SlackLink, SlackText, SlackTextContent, SlackTime,
 mod macros;
 mod attachment;
 mod error;
-mod helper;
 mod hex;
 mod payload;
 mod slack;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
     unused_qualifications,
     unused_results
 )]
+#![warn(rust_2018_idioms)]
 
 //! Library to send messages to slack rooms
 //! supports entire messaging API, including attachments and fields

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,9 @@
     unstable_features,
     unused_import_braces,
     unused_qualifications,
-    unused_results
+    unused_results,
+    rust_2018_idioms
 )]
-#![warn(rust_2018_idioms)]
 
 //! Library to send messages to slack rooms
 //! supports entire messaging API, including attachments and fields
@@ -32,53 +32,3 @@ mod error;
 mod hexx;
 mod payload;
 mod slack;
-
-/// Waiting to stabilize: https://github.com/rust-lang/rust/issues/33417
-///
-/// An attempted conversion that consumes `self`, which may or may not be expensive.
-///
-/// Library authors should not directly implement this trait, but should prefer implementing
-/// the [`TryFrom`] trait, which offers greater flexibility and provides an equivalent `TryInto`
-/// implementation for free, thanks to a blanket implementation in the standard library.
-///
-/// [`TryFrom`]: trait.TryFrom.html
-pub trait TryInto<T>: Sized {
-    /// The type returned in the event of a conversion error.
-    type Err;
-
-    /// Performs the conversion.
-    fn try_into(self) -> ::std::result::Result<T, Self::Err>;
-}
-
-/// Waiting to stabilize: https://github.com/rust-lang/rust/issues/33417
-///
-/// Attempt to construct `Self` via a conversion.
-pub trait TryFrom<T>: Sized {
-    /// The type returned in the event of a conversion error.
-    type Err;
-
-    /// Performs the conversion.
-    fn try_from(_: T) -> ::std::result::Result<Self, Self::Err>;
-}
-
-impl<T, U> TryInto<U> for T
-where
-    U: TryFrom<T>,
-{
-    type Err = U::Err;
-
-    fn try_into(self) -> ::std::result::Result<U, U::Err> {
-        U::try_from(self)
-    }
-}
-
-impl<'a> TryFrom<&'a str> for reqwest::Url {
-    type Err = Error;
-
-    fn try_from(s: &str) -> ::std::result::Result<Self, Self::Err> {
-        match s.parse() {
-            Ok(u) => Ok(u),
-            Err(e) => Err(e.into()),
-        }
-    }
-}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -5,15 +5,15 @@ macro_rules! url_builder_fn {
         $name:ident, $builder:ident
     } => {
         $(#[$meta])+
-        pub fn $name<U: TryInto<::reqwest::Url, Err = Error>>(self, $name: U) -> $builder {
+        pub fn $name(self, $name: &str) -> $builder {
             match self.inner {
                 Ok(mut inner) => {
-                    match $name.try_into() {
+                    match Url::parse($name) {
                         Ok(url) => {
                             inner.$name = Some(url);
                             $builder { inner: Ok(inner) }
                         }
-                        Err(e) => $builder { inner: Err(e) },
+                        Err(e) => $builder { inner: Err(e.into()) },
                     }
                 }
                 _ => self,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -5,10 +5,10 @@ macro_rules! url_builder_fn {
         $name:ident, $builder:ident
     } => {
         $(#[$meta])+
-        pub fn $name(self, $name: &str) -> $builder {
+        pub fn $name<U: ::reqwest::IntoUrl>(self, $name: U) -> $builder {
             match self.inner {
                 Ok(mut inner) => {
-                    match Url::parse($name) {
+                    match $name.into_url() {
                         Ok(url) => {
                             inner.$name = Some(url);
                             $builder { inner: Ok(inner) }

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -1,5 +1,5 @@
-use crate::error::{Error, Result};
-use crate::{Attachment, SlackText, TryInto};
+use crate::error::Result;
+use crate::{Attachment, SlackText};
 use reqwest::Url;
 use serde::{Serialize, Serializer};
 

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -1,8 +1,7 @@
 use crate::error::{Error, Result};
-use crate::helper::bool_to_u8;
+use crate::{Attachment, SlackText, TryInto};
 use reqwest::Url;
 use serde::{Serialize, Serializer};
-use crate::{Attachment, SlackText, TryInto};
 
 /// Payload to send to slack
 /// https://api.slack.com/incoming-webhooks
@@ -178,7 +177,7 @@ impl PayloadBuilder {
     pub fn link_names(self, b: bool) -> PayloadBuilder {
         match self.inner {
             Ok(mut inner) => {
-                inner.link_names = Some(bool_to_u8(b));
+                inner.link_names = Some(u8::from(b));
                 PayloadBuilder { inner: Ok(inner) }
             }
             _ => self,

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -1,8 +1,8 @@
-use error::{Error, Result};
-use helper::bool_to_u8;
+use crate::error::{Error, Result};
+use crate::helper::bool_to_u8;
 use reqwest::Url;
 use serde::{Serialize, Serializer};
-use {Attachment, SlackText, TryInto};
+use crate::{Attachment, SlackText, TryInto};
 
 /// Payload to send to slack
 /// https://api.slack.com/incoming-webhooks

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -121,7 +121,7 @@ impl<'a> From<&'a [SlackTextContent]> for SlackText {
 }
 
 impl fmt::Display for SlackText {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
@@ -149,7 +149,7 @@ impl SlackLink {
 }
 
 impl fmt::Display for SlackLink {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "<{}|{}>", self.url, self.text)
     }
 }
@@ -183,7 +183,7 @@ impl SlackUserLink {
 }
 
 impl fmt::Display for SlackUserLink {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "<{}>", self.uid)
     }
 }

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -1,9 +1,9 @@
 use chrono::NaiveDateTime;
-use error::{Error, ErrorKind, Result};
+use crate::error::{Error, ErrorKind, Result};
 use reqwest::{Client, Url};
 use serde::{Serialize, Serializer};
 use std::fmt;
-use {Payload, TryInto};
+use crate::{Payload, TryInto};
 
 /// Handles sending messages to slack
 #[derive(Debug, Clone)]
@@ -200,10 +200,10 @@ impl Serialize for SlackUserLink {
 #[cfg(test)]
 mod test {
     use chrono::NaiveDateTime;
-    use slack::{Slack, SlackLink};
+    use crate::slack::{Slack, SlackLink};
     #[cfg(feature = "unstable")]
     use test::Bencher;
-    use {serde_json, AttachmentBuilder, Field, Parse, PayloadBuilder, SlackText};
+    use crate::{serde_json, AttachmentBuilder, Field, Parse, PayloadBuilder, SlackText};
 
     #[test]
     fn slack_incoming_url_test() {

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -1,9 +1,9 @@
-use chrono::NaiveDateTime;
 use crate::error::{Error, ErrorKind, Result};
+use crate::{Payload, TryInto};
+use chrono::NaiveDateTime;
 use reqwest::{Client, Url};
 use serde::{Serialize, Serializer};
 use std::fmt;
-use crate::{Payload, TryInto};
 
 /// Handles sending messages to slack
 #[derive(Debug, Clone)]
@@ -199,11 +199,11 @@ impl Serialize for SlackUserLink {
 
 #[cfg(test)]
 mod test {
-    use chrono::NaiveDateTime;
     use crate::slack::{Slack, SlackLink};
+    use crate::{AttachmentBuilder, Field, Parse, PayloadBuilder, SlackText};
+    use chrono::NaiveDateTime;
     #[cfg(feature = "unstable")]
     use test::Bencher;
-    use crate::{serde_json, AttachmentBuilder, Field, Parse, PayloadBuilder, SlackText};
 
     #[test]
     fn slack_incoming_url_test() {

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -1,5 +1,5 @@
-use crate::error::{Error, ErrorKind, Result};
-use crate::{Payload, TryInto};
+use crate::error::{ErrorKind, Result};
+use crate::Payload;
 use chrono::NaiveDateTime;
 use reqwest::{Client, Url};
 use serde::{Serialize, Serializer};
@@ -14,9 +14,9 @@ pub struct Slack {
 
 impl Slack {
     /// Construct a new instance of slack for a specific incoming url endpoint.
-    pub fn new<T: TryInto<Url, Err = Error>>(hook: T) -> Result<Slack> {
+    pub fn new<T: reqwest::IntoUrl>(hook: T) -> Result<Slack> {
         Ok(Slack {
-            hook: hook.try_into()?,
+            hook: hook.into_url()?,
             client: Client::new(),
         })
     }


### PR DESCRIPTION
This updates things to fall more in line with post-2018-edition rust along with some small cleanup

I believe that I avoided any unnecessary breaking changes. The only difficult part was dealing with `TryInto<reqwest::Url, Error = crate::Error>` which worked when using the library's `TryInto` implementation, but can't work with `std`'s because of the orphan rule. Switching to `reqwest::Url` should accept the same values and still can bubble the error up to a `crate::Error` though

I also removed the `#![cfg_attr(test, deny(warnings))]` since it's a bit annoying for my workflow where I generally use a program to watch the source files and run tests when it sees a file changed (using [bacon](https://github.com/Canop/bacon) while another good alternative is [cargo-watch](https://lib.rs/crates/cargo-watch)). It's a bit cumbersome to not be able to easily differentiate between warnings and errors when working like this and I don't think it's a big issue since warnings are denied in CI