### PR TITLE
Fix `cargo doc` warnings

### DIFF
--- a/src/attachment.rs
+++ b/src/attachment.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 use std::convert::TryInto;
 
 /// Slack allows for attachments to be added to messages. See
-/// https://api.slack.com/docs/attachments for more information.
+/// <https://api.slack.com/docs/attachments> for more information.
 #[derive(Serialize, Debug, Default, Clone, PartialEq)]
 pub struct Attachment {
     /// Required text for attachment.

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -39,7 +39,7 @@ impl TryFrom<&str> for HexColor {
 }
 
 /// Default slack colors built-in to the API
-/// See: https://api.slack.com/docs/attachments
+/// See: <https://api.slack.com/docs/attachments>
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum SlackColor {
     /// green

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -4,8 +4,8 @@ use reqwest::Url;
 use serde::{Serialize, Serializer};
 
 /// Payload to send to slack
-/// https://api.slack.com/incoming-webhooks
-/// https://api.slack.com/methods/chat.postMessage
+/// <https://api.slack.com/incoming-webhooks>
+/// <https://api.slack.com/methods/chat.postMessage>
 #[derive(Serialize, Debug, Default)]
 pub struct Payload {
     /// text to send
@@ -25,14 +25,14 @@ pub struct Payload {
     #[serde(with = "::url_serde")]
     pub icon_url: Option<Url>,
     /// emjoi for icon
-    /// https://api.slack.com/methods/emoji.list
+    /// <https://api.slack.com/methods/emoji.list>
     #[serde(skip_serializing_if = "Option::is_none")]
     pub icon_emoji: Option<String>,
     /// attachments to send
     #[serde(skip_serializing_if = "Option::is_none")]
     pub attachments: Option<Vec<Attachment>>,
     /// whether slack will try to fetch links and create an attachment
-    /// https://api.slack.com/docs/unfurling
+    /// <https://api.slack.com/docs/unfurling>
     #[serde(skip_serializing_if = "Option::is_none")]
     pub unfurl_links: Option<bool>,
     /// Pass false to disable unfurling of media content
@@ -148,7 +148,7 @@ impl PayloadBuilder {
     }
 
     /// whether slack will try to fetch links and create an attachment
-    /// https://api.slack.com/docs/unfurling
+    /// <https://api.slack.com/docs/unfurling>
     pub fn unfurl_links(self, b: bool) -> PayloadBuilder {
         match self.inner {
             Ok(mut inner) => {

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -61,7 +61,7 @@ pub struct SlackText(String);
 impl SlackText {
     /// Construct slack text with escaping
     /// Escape &, <, and > in any slack text
-    /// https://api.slack.com/docs/formatting
+    /// <https://api.slack.com/docs/formatting>
     pub fn new<S: Into<String>>(text: S) -> SlackText {
         let s = text.into().chars().fold(String::new(), |mut s, c| {
             match c {
@@ -166,7 +166,7 @@ impl Serialize for SlackLink {
 /// Representation of a user id link sent in slack
 ///
 /// Cannot do @UGUID|handle links using SlackLink in the future due to
-/// https://api.slack.com/changelog/2017-09-the-one-about-usernames
+/// <https://api.slack.com/changelog/2017-09-the-one-about-usernames>
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub struct SlackUserLink {
     /// User ID (U1231232123) style


### PR DESCRIPTION
When running `cargo doc` I noticed some warnings about bare urls that aren't actually treated as hyperlinks. This PR just switches them to automatic links for ease of use when looking at the generated documentation.

I was hoping that I could add checking for doc warnings to CI, but it looks like there is still [ongoing work for stabilizing that functionality](https://github.com/rust-lang/cargo/issues/10025). I don't want to switch to using unstable features that may change before stabilizing, but definitely good to keep an eye on for the future.