### PR TITLE
Update outdated deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,8 @@ edition = "2018"
 [dependencies]
 chrono = "0.4"
 reqwest = "0.9"
-hex = "0.3"
-error-chain = "~0.11"
-serde = "1"
-serde_derive = "1"
+hex = "0.4"
+error-chain = "0.12"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 url_serde = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,10 @@ edition = "2018"
 
 [dependencies]
 chrono = "0.4"
-reqwest = "0.9"
+reqwest = { version = "0.11", features = ["blocking", "json"] }
 hex = "0.4"
 error-chain = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
-url_serde = "0.2"
+# Used to access some functionality that isn't directly rexposed by `reqwest`
+url = { version = "2.2", features = ["serde"] }

--- a/src/attachment.rs
+++ b/src/attachment.rs
@@ -34,28 +34,23 @@ pub struct Attachment {
     /// Optional URL that will hyperlink the `author_name` text mentioned above. Will only
     /// work if `author_name` is present.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(with = "::url_serde")]
     pub author_link: Option<Url>,
     /// Optional URL that displays a small 16x16px image to the left of
     /// the `author_name` text. Will only work if `author_name` is present.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(with = "::url_serde")]
     pub author_icon: Option<Url>,
     /// Optional larger, bolder text above the main body
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<SlackText>,
     /// Optional URL to link to from the title
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(with = "::url_serde")]
     pub title_link: Option<Url>,
     /// Optional URL to an image that will be displayed in the body
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(with = "::url_serde")]
     pub image_url: Option<Url>,
     /// Optional URL to an image that will be displayed as a thumbnail to the
     /// right of the body
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(with = "::url_serde")]
     pub thumb_url: Option<Url>,
     /// Optional text that will appear at the bottom of the attachment
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -63,7 +58,6 @@ pub struct Attachment {
     /// Optional URL to an image that will be displayed at the bottom of the
     /// attachment
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(with = "::url_serde")]
     pub footer_icon: Option<Url>,
     /// Optional timestamp to be displayed with the attachment
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,14 +1,10 @@
 error_chain! {
-    types {
-        Error, ErrorKind, ResultExt, Result;
-    }
-
     foreign_links {
         Utf8(::std::str::Utf8Error) #[doc = "utf8 error, slack responses should be valid utf8"];
         Serialize(::serde_json::error::Error) #[doc = "`serde_json::error::Error`"];
         FromHex(::hex::FromHexError) #[doc = "`rustc_serialize::hex::FromHexError`"];
         Reqwest(::reqwest::Error) #[doc = "`reqwest::Error`"];
-        Url(::reqwest::UrlError) #[doc = "`reqwest::UrlError`"];
+        Url(::url::ParseError) #[doc = "`url::ParseError`"];
         Io(::std::io::Error) #[doc = "`std::io::Error`"];
     }
 

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -22,7 +22,6 @@ pub struct Payload {
     pub username: Option<String>,
     /// specific url for icon
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(with = "::url_serde")]
     pub icon_url: Option<Url>,
     /// emjoi for icon
     /// https://api.slack.com/methods/emoji.list

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -1,7 +1,7 @@
 use crate::error::{ErrorKind, Result};
 use crate::Payload;
 use chrono::NaiveDateTime;
-use reqwest::{Client, Url};
+use reqwest::{blocking::Client, Url};
 use serde::{Serialize, Serializer};
 use std::fmt;
 


### PR DESCRIPTION
This pull request updates `error-chain`, `hex`, and `reqwest` to their most recently release version while dropping `serde_derive` and `url_serde` by using features to expose the same functionality on the base crates instead.

This was all of the low hanging fruit where the only complicated update was with `reqwest` (done in a separate commit) which involved some basic changes around `Url`s and switching to the `blocking::Client` to still mimic the old behavior since the async client is now the default. The plan is to eventually expose both sync and async functions in the future.

Not included in this PR is switching away from `error-chain` (preferably to `thiserror`). `error-chain` is no longer maintained (the github repo now lives under `rust-lang-deprecated` as an archived repo). I haven't switched away quite yet because it will be a pretty blatant breaking change with `error-chain` exposing an error type that includes an `ErrorKind` which is pretty unique compared to the standard way of exposing errors now, so it's possible that we want to do a release before switching away from `error-chain`