### PR TITLE
Resolve current warnings

### DIFF
--- a/src/hex.rs
+++ b/src/hex.rs
@@ -150,7 +150,7 @@ mod test {
 
     #[test]
     fn test_hex_color_good() {
-        let h: HexColor = HexColor::try_from(SlackColor::Good).unwrap();
+        let h: HexColor = HexColor::from(SlackColor::Good);
         assert_eq!(h.to_string(), "good");
     }
 

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -49,7 +49,7 @@ impl Serialize for SlackTime {
     where
         S: Serializer,
     {
-        serializer.serialize_i64(self.0.timestamp())
+        serializer.serialize_i64(self.0.and_utc().timestamp())
     }
 }
 
@@ -201,7 +201,7 @@ impl Serialize for SlackUserLink {
 mod test {
     use crate::slack::{Slack, SlackLink};
     use crate::{AttachmentBuilder, Field, Parse, PayloadBuilder, SlackText};
-    use chrono::NaiveDateTime;
+    use chrono::DateTime;
 
     #[test]
     fn slack_incoming_url_test() {
@@ -249,7 +249,9 @@ mod test {
             .color("#6800e8")
             .fields(vec![Field::new("title", "value", None)])
             .title_link("https://title_link.com/")
-            .ts(&NaiveDateTime::from_timestamp(123_456_789, 0))
+            .ts(&DateTime::from_timestamp(123_456_789, 0)
+                .unwrap()
+                .naive_utc())
             .build()
             .unwrap()];
 

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -86,7 +86,7 @@ impl<'a> From<&'a str> for SlackText {
     }
 }
 
-impl<'a> From<String> for SlackText {
+impl From<String> for SlackText {
     fn from(s: String) -> SlackText {
         SlackText::new(s)
     }
@@ -105,7 +105,7 @@ pub enum SlackTextContent {
     User(SlackUserLink),
 }
 
-impl<'a> From<&'a [SlackTextContent]> for SlackText {
+impl From<&[SlackTextContent]> for SlackText {
     fn from(v: &[SlackTextContent]) -> SlackText {
         let st = v
             .iter()

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -202,8 +202,6 @@ mod test {
     use crate::slack::{Slack, SlackLink};
     use crate::{AttachmentBuilder, Field, Parse, PayloadBuilder, SlackText};
     use chrono::NaiveDateTime;
-    #[cfg(feature = "unstable")]
-    use test::Bencher;
 
     #[test]
     fn slack_incoming_url_test() {


### PR DESCRIPTION
Resolves all of the existing warnings aside from one `clippy` lint that's triggering from inside of `error-chain`. I'm planning on dropping that in a separate PR that switches from `error-chain` to a handwritten error impl