### PR TITLE
refactor: Drop `error-chain` for a manual impl

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -63,6 +63,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          # FIXME: currently `error_chain` causes some deprecation warnings, so
-          # temporaily allow warnings until that gets sorted out
-          # args: -- -D warnings
+          args: -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,16 +165,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "error-chain"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
-dependencies = [
- "backtrace",
- "version_check",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,7 +914,6 @@ name = "slack-hook"
 version = "0.9.0-dev"
 dependencies = [
  "chrono",
- "error-chain",
  "hex",
  "reqwest",
  "serde",
@@ -1131,12 +1120,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 chrono = "0.4.39"
 reqwest = { version = "0.11.27", features = ["blocking", "json"] }
 hex = "0.4.3"
-error-chain = "0.12.4"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.135"
 # Used to access some functionality that isn't directly rexposed by `reqwest`

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,23 +1,80 @@
-error_chain! {
-    foreign_links {
-        Utf8(::std::str::Utf8Error) #[doc = "utf8 error, slack responses should be valid utf8"];
-        Serialize(::serde_json::error::Error) #[doc = "`serde_json::error::Error`"];
-        FromHex(::hex::FromHexError) #[doc = "`rustc_serialize::hex::FromHexError`"];
-        Reqwest(::reqwest::Error) #[doc = "`reqwest::Error`"];
-        Url(::url::ParseError) #[doc = "`url::ParseError`"];
-        Io(::std::io::Error) #[doc = "`std::io::Error`"];
-    }
+use std::{fmt, str::Utf8Error};
 
-    errors {
-        /// slack service error
-        Slack(err: String) {
-            description("slack service error")
-            display("slack service error: {}", err)
-        }
-        /// `HexColor` parsing error
-        HexColor(err: String) {
-            description("hex color parsing error")
-            display("hex color parsing error: {}", err)
+use hex::FromHexError;
+
+/// An alias for a `Result` with a `slack_hook::Error`
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// The all-encompassing error type for the `slack-hook` crate
+#[derive(Debug)]
+pub enum Error {
+    /// slack service error
+    Slack(String),
+    /// Hex color parsing error
+    HexColor(String),
+    /// utf8 error, slack responses should be valid utf8
+    Utf8(Utf8Error),
+    /// `serde_json::Error`
+    Serialize(serde_json::Error),
+    /// `hex::FromHexError`
+    FromHex(FromHexError),
+    /// `reqwest::Error`
+    Reqwest(reqwest::Error),
+    /// `url::ParseError`
+    Url(url::ParseError),
+    /// `std::io::Error`
+    Io(std::io::Error),
+}
+
+impl From<Utf8Error> for Error {
+    fn from(utf8_err: Utf8Error) -> Self {
+        Self::Utf8(utf8_err)
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(json_err: serde_json::Error) -> Self {
+        Self::Serialize(json_err)
+    }
+}
+
+impl From<FromHexError> for Error {
+    fn from(hex_err: FromHexError) -> Self {
+        Self::FromHex(hex_err)
+    }
+}
+
+impl From<reqwest::Error> for Error {
+    fn from(reqwest_err: reqwest::Error) -> Self {
+        Self::Reqwest(reqwest_err)
+    }
+}
+
+impl From<url::ParseError> for Error {
+    fn from(url_err: url::ParseError) -> Self {
+        Self::Url(url_err)
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(io_err: std::io::Error) -> Self {
+        Self::Io(io_err)
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Slack(err) => write!(f, "slack service error: {err}"),
+            Self::HexColor(err) => write!(f, "hex color parsing error: {err}"),
+            Self::Utf8(err) => err.fmt(f),
+            Self::Serialize(err) => err.fmt(f),
+            Self::FromHex(err) => err.fmt(f),
+            Self::Reqwest(err) => err.fmt(f),
+            Self::Url(err) => err.fmt(f),
+            Self::Io(err) => err.fmt(f),
         }
     }
 }
+
+impl std::error::Error for Error {}

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -1,4 +1,4 @@
-use crate::error::{Error, ErrorKind};
+use crate::error::Error;
 use std::{convert::TryFrom, str::FromStr};
 
 use hex::FromHex;
@@ -85,15 +85,14 @@ impl FromStr for HexColor {
 
         let num_chars = s.chars().count();
         if num_chars != 7 && num_chars != 4 {
-            return Err(ErrorKind::HexColor(format!(
+            return Err(Error::HexColor(format!(
                 "Must be 4 or 7 characters long (including #): \
                  found `{}`",
                 s
-            ))
-            .into());
+            )));
         }
         if !s.starts_with('#') {
-            return Err(ErrorKind::HexColor(format!("No leading #: found `{}`", s)).into());
+            return Err(Error::HexColor(format!("No leading #: found `{}`", s)));
         }
 
         // #d18 -> #dd1188

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,9 +20,6 @@
 #[cfg(doctest)]
 pub struct ReadmeDoctests;
 
-#[macro_use]
-extern crate error_chain;
-
 pub use crate::attachment::{Action, Attachment, AttachmentBuilder, Field, Section};
 pub use crate::error::{Error, Result};
 pub use crate::hex::{HexColor, SlackColor};

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -1,4 +1,4 @@
-use crate::error::{ErrorKind, Result};
+use crate::error::{Error, Result};
 use crate::Payload;
 use chrono::NaiveDateTime;
 use reqwest::{blocking::Client, Url};
@@ -28,7 +28,7 @@ impl Slack {
         if response.status().is_success() {
             Ok(())
         } else {
-            Err(ErrorKind::Slack(format!("HTTP error {}", response.status())).into())
+            Err(Error::Slack(format!("HTTP error {}", response.status())))
         }
     }
 }


### PR DESCRIPTION
Drops `error-chain` in favor of a handwritten `Error` impl with the typical bells and whistles[^1]. We could also use some library to cut down on boilerplate like `thiserror`, but it's not currently in our dep tree, so I opted to avoid it for now

[^1]: I'd like to improve things further later, but this is sticking close to the old impl for now