### PR TITLE
ci: Pull CI back into the modern age

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -1,6 +1,9 @@
 on: [push, pull_request]
 
-name: "Build, Test, and Styling"
+name: CI
+
+env:
+  CARGO_TERM_COLOR: always
 
 jobs:
   basic:
@@ -13,54 +16,24 @@ jobs:
           - beta
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install ${{ matrix.rust }} toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
-          components: rustfmt, clippy
-
-      # The `rustc` version will change as the channel updates so pin the cache
-      # to the specific version
-      - name: Get rustc version
-        id: get-version
         run: |
-          echo "::set-output name=version::$(rustc -V | sed 's/ /_/g')"
+          rustup toolchain install ${{ matrix.rust }} --profile minimal --component rustfmt,clippy
+          rustup default ${{ matrix.rust }}
 
-      - name: Cargo registry cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.cargo/registry
-          key: basic-cargo-registry-${{ steps.get-version.outputs.version }}
-
-      - name: Cargo build cache
-        uses: actions/cache@v2
-        with:
-          path: target
-          key: basic-cargo-build-${{ steps.get-version.outputs.version }}
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Build all targets
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --all-targets
+        run: cargo build --all-targets
 
       - name: Run the test suite
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+        run: cargo test
 
       - name: Check formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -- --check
+        run: cargo fmt --check
 
       - name: Check clippy lints
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+        run: cargo clippy -- -D warnings


### PR DESCRIPTION
- Drops `actions-rs` now that it's no longer maintained in favor of the runner installed `rustup`
- Switches manual caching over to `Swatinem/rust-cache`
- Misc changes