### PR TITLE
Miscellaneous internal and test cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,6 +150,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -540,6 +558,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6513e4067e16e69ed1db5ab56048ed65db32d10ba5fc1217f5393f8f17d8b5a5"
+dependencies = [
+ "console",
+ "linked-hash-map",
+ "once_cell",
+ "serde",
+ "similar",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,6 +597,12 @@ name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -901,6 +938,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "similar"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,6 +958,7 @@ version = "0.9.0-dev"
 dependencies = [
  "chrono",
  "hex",
+ "insta",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.135"
 # Used to access some functionality that isn't directly rexposed by `reqwest`
 url = { version = "2.5.4", features = ["serde"] }
+
+[dev-dependencies]
+insta = { version = "1.42.0", features = ["json"] }

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -1,5 +1,5 @@
 use crate::error::Error;
-use std::{convert::TryFrom, str::FromStr};
+use std::{convert::TryFrom, fmt, str::FromStr};
 
 use hex::FromHex;
 use serde::Serialize;
@@ -12,6 +12,7 @@ use serde::Serialize;
 /// hex color codes will be checked to ensure a valid hex number is provided
 #[derive(Serialize, Debug, Clone, PartialEq)]
 pub struct HexColor(String);
+
 impl HexColor {
     fn new<S: Into<String>>(s: S) -> HexColor {
         HexColor(s.into())
@@ -24,12 +25,13 @@ impl Default for HexColor {
     }
 }
 
-impl ::std::fmt::Display for HexColor {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{}", self.0)
+impl fmt::Display for HexColor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
     }
 }
 
+// FIXME(cosmic): Why provide this when there's already `FromStr`? Some generic bound maybe?
 impl TryFrom<&str> for HexColor {
     type Error = Error;
 
@@ -52,9 +54,9 @@ pub enum SlackColor {
 
 const SLACK_COLORS: [&str; 3] = ["good", "warning", "danger"];
 
-impl ::std::fmt::Display for SlackColor {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{}", self.as_ref())
+impl fmt::Display for SlackColor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_ref().fmt(f)
     }
 }
 
@@ -149,7 +151,7 @@ mod test {
 
     #[test]
     fn test_hex_color_good() {
-        let h: HexColor = HexColor::from(SlackColor::Good);
+        let h: HexColor = SlackColor::Good.into();
         assert_eq!(h.to_string(), "good");
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+// TODO(cosmic): switch from deny to warn (except for `unsafe_code`) and prune some of these
 #![deny(
     missing_docs,
     missing_debug_implementations,
@@ -20,6 +21,7 @@
 #[cfg(doctest)]
 pub struct ReadmeDoctests;
 
+// TODO(cosmic): We probably want _some_ level of nesting instead of having everything in the root
 pub use crate::attachment::{Action, Attachment, AttachmentBuilder, Field, Section};
 pub use crate::error::{Error, Result};
 pub use crate::hex::{HexColor, SlackColor};

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -1,5 +1,4 @@
-use crate::error::Result;
-use crate::{Attachment, SlackText};
+use crate::{Attachment, Result, SlackText};
 use reqwest::Url;
 use serde::{Serialize, Serializer};
 
@@ -23,7 +22,7 @@ pub struct Payload {
     /// specific url for icon
     #[serde(skip_serializing_if = "Option::is_none")]
     pub icon_url: Option<Url>,
-    /// emjoi for icon
+    /// emoji for icon
     /// <https://api.slack.com/methods/emoji.list>
     #[serde(skip_serializing_if = "Option::is_none")]
     pub icon_emoji: Option<String>,
@@ -68,6 +67,7 @@ impl Serialize for Parse {
 }
 /// `PayloadBuilder` is used to build a `Payload`
 #[derive(Debug)]
+#[must_use]
 pub struct PayloadBuilder {
     inner: Result<Payload>,
 }
@@ -82,116 +82,88 @@ impl Default for PayloadBuilder {
 
 impl PayloadBuilder {
     /// Make a new `PayloadBuilder`
-    pub fn new() -> PayloadBuilder {
+    pub fn new() -> Self {
         Default::default()
     }
 
     /// Set the text
-    pub fn text<S: Into<SlackText>>(self, text: S) -> PayloadBuilder {
-        match self.inner {
-            Ok(mut inner) => {
-                inner.text = Some(text.into());
-                PayloadBuilder { inner: Ok(inner) }
-            }
-            _ => self,
+    pub fn text<S: Into<SlackText>>(mut self, text: S) -> Self {
+        if let Ok(inner) = &mut self.inner {
+            inner.text = Some(text.into());
         }
+        self
     }
 
     /// Set the channel
-    pub fn channel<S: Into<String>>(self, channel: S) -> PayloadBuilder {
-        match self.inner {
-            Ok(mut inner) => {
-                inner.channel = Some(channel.into());
-                PayloadBuilder { inner: Ok(inner) }
-            }
-            _ => self,
+    pub fn channel<S: Into<String>>(mut self, channel: S) -> Self {
+        if let Ok(inner) = &mut self.inner {
+            inner.channel = Some(channel.into());
         }
+        self
     }
 
     /// Set the username
-    pub fn username<S: Into<String>>(self, username: S) -> PayloadBuilder {
-        match self.inner {
-            Ok(mut inner) => {
-                inner.username = Some(username.into());
-                PayloadBuilder { inner: Ok(inner) }
-            }
-            _ => self,
+    pub fn username<S: Into<String>>(mut self, username: S) -> Self {
+        if let Ok(inner) = &mut self.inner {
+            inner.username = Some(username.into());
         }
+        self
     }
 
     /// Set the icon_emoji
-    pub fn icon_emoji<S: Into<String>>(self, icon_emoji: S) -> PayloadBuilder {
-        match self.inner {
-            Ok(mut inner) => {
-                inner.icon_emoji = Some(icon_emoji.into());
-                PayloadBuilder { inner: Ok(inner) }
-            }
-            _ => self,
+    pub fn icon_emoji<S: Into<String>>(mut self, icon_emoji: S) -> Self {
+        if let Ok(inner) = &mut self.inner {
+            inner.icon_emoji = Some(icon_emoji.into());
         }
+        self
     }
 
     url_builder_fn! {
         /// Set the icon_url
-        icon_url, PayloadBuilder
+        icon_url, Self
     }
 
     /// Set the attachments
-    pub fn attachments(self, attachments: Vec<Attachment>) -> PayloadBuilder {
-        match self.inner {
-            Ok(mut inner) => {
-                inner.attachments = Some(attachments);
-                PayloadBuilder { inner: Ok(inner) }
-            }
-            _ => self,
+    pub fn attachments(mut self, attachments: Vec<Attachment>) -> Self {
+        if let Ok(inner) = &mut self.inner {
+            inner.attachments = Some(attachments);
         }
+        self
     }
 
     /// whether slack will try to fetch links and create an attachment
     /// <https://api.slack.com/docs/unfurling>
-    pub fn unfurl_links(self, b: bool) -> PayloadBuilder {
-        match self.inner {
-            Ok(mut inner) => {
-                inner.unfurl_links = Some(b);
-                PayloadBuilder { inner: Ok(inner) }
-            }
-            _ => self,
+    pub fn unfurl_links(mut self, b: bool) -> Self {
+        if let Ok(inner) = &mut self.inner {
+            inner.unfurl_links = Some(b);
         }
+        self
     }
 
     /// Pass false to disable unfurling of media content
-    pub fn unfurl_media(self, b: bool) -> PayloadBuilder {
-        match self.inner {
-            Ok(mut inner) => {
-                inner.unfurl_media = Some(b);
-                PayloadBuilder { inner: Ok(inner) }
-            }
-            _ => self,
+    pub fn unfurl_media(mut self, b: bool) -> Self {
+        if let Ok(inner) = &mut self.inner {
+            inner.unfurl_media = Some(b);
         }
+        self
     }
 
     /// Find and link channel names and usernames.
     // NOTE: The Slack API doesn't seem to actually require setting `link_names` to 1, any value
-    // seems to work. However, to be faithful to their spec, we will keep the `bool_to_u8` fn
-    // around.
-    pub fn link_names(self, b: bool) -> PayloadBuilder {
-        match self.inner {
-            Ok(mut inner) => {
-                inner.link_names = Some(u8::from(b));
-                PayloadBuilder { inner: Ok(inner) }
-            }
-            _ => self,
+    // seems to work. However, to be faithful to their spec we will stick to 0 and 1
+    pub fn link_names(mut self, b: bool) -> Self {
+        if let Ok(inner) = &mut self.inner {
+            inner.link_names = Some(u8::from(b));
         }
+        self
     }
 
     /// Change how messages are treated.
-    pub fn parse(self, p: Parse) -> PayloadBuilder {
-        match self.inner {
-            Ok(mut inner) => {
-                inner.parse = Some(p);
-                PayloadBuilder { inner: Ok(inner) }
-            }
-            _ => self,
+    pub fn parse(mut self, p: Parse) -> Self {
+        if let Ok(inner) = &mut self.inner {
+            inner.parse = Some(p);
         }
+        self
     }
 
     /// Attempt to build the `Payload`


### PR DESCRIPTION
Cleans up some common patterns (particularly the `match`es used in the builder methods which will likely be changed even more in the future), lots of TODOs and FIXMEs sprinkled around, and a soft rework of the test suite