### PR TITLE
Release v0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slack-hook"
-version = "0.9.0-rc.1"
+version = "0.9.0"
 description = "A rust crate for sending messages to Slack via webhooks."
 authors = ["Christopher Brickley <brickley@gmail.com>"]
 keywords = ["slack", "webhook", "hook", "messaging"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.9.0-rc.1"
 description = "A rust crate for sending messages to Slack via webhooks."
 authors = ["Christopher Brickley <brickley@gmail.com>"]
 keywords = ["slack", "webhook", "hook", "messaging"]
+categories = ["api-bindings", "web-programming"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frostly/rust-slack"
 edition = "2018"


### PR DESCRIPTION
It's been less than a week, but I'm getting ansty. There's been over a hundred downloads of the new version already[^1], the docs built and seem fine, and lib.rs only nags on the latest stable release being old and the lack of `categories` (which was addressed in 8b8d4d91dcdade0b5c9052987e13193ebe453f08). Worst case we can always just cut a new release of course

[^1]: chances are a good chunk is automated, but there's likely still quite a few genuine downloads