### PR TITLE
chore: Let cargo mess with the lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "slack-hook"
-version = "0.9.0-rc.1"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "hex",


### PR DESCRIPTION
We should really add a basic release checklist to help ensure this doesn't happen more in the future